### PR TITLE
feat : slider 내부 이미지 아이콘 색상 및 배경 색상 지정

### DIFF
--- a/app/components/base/image-slider.tsx
+++ b/app/components/base/image-slider.tsx
@@ -9,6 +9,7 @@ import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 import { useKeenSlider } from 'keen-slider/react';
 import 'keen-slider/keen-slider.min.css';
 import { KeenSliderHooks, KeenSliderInstance } from 'keen-slider';
+import Link from 'next/link';
 
 interface CarouselArrowProps {
   disabled: boolean;
@@ -102,24 +103,26 @@ export default function ImageSlider({
       <div className="relative">
         <div ref={sliderRef} className="keen-slider h-[320px] md:h-[520px]">
           {_.map(images, (image, i) => (
-            <div
-              key={i}
-              // className="flex justify-center items-center overflow-hidden h-[320px] md:h-[520px] "
-              className="keen-slider__slide"
-              style={{
-                position: 'relative',
-                // objectFit: 'cover',
-              }}
-            >
-              <NextImage
-                src={image.url}
-                alt={image.name}
-                width={width}
-                height={height}
-                // fill
-                loading="lazy"
-              />
-            </div>
+            <Link key={image.id + i} href={image.url} target="_blank">
+              <div
+                key={i}
+                // className="flex justify-center items-center overflow-hidden h-[320px] md:h-[520px] "
+                className="keen-slider__slide"
+                style={{
+                  position: 'relative',
+                  // objectFit: 'cover',
+                }}
+              >
+                <NextImage
+                  src={image.url}
+                  alt={image.name}
+                  width={width}
+                  height={height}
+                  // fill
+                  loading="lazy"
+                />
+              </div>
+            </Link>
           ))}
         </div>
         {loaded && instanceRef.current && images && images.length > 1 && (

--- a/app/components/base/image-slider.tsx
+++ b/app/components/base/image-slider.tsx
@@ -5,11 +5,16 @@ import _ from 'lodash';
 import { Image } from 'prisma';
 import NextImage from 'next/image';
 import { IconButton } from '@mui/material';
-import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  MagnifyingGlassIcon,
+} from '@heroicons/react/24/outline';
 import { useKeenSlider } from 'keen-slider/react';
 import 'keen-slider/keen-slider.min.css';
 import { KeenSliderHooks, KeenSliderInstance } from 'keen-slider';
 import Link from 'next/link';
+import { isMobile } from 'react-device-detect';
 
 interface CarouselArrowProps {
   disabled: boolean;
@@ -26,6 +31,25 @@ interface NavigationProps {
     KeenSliderHooks
   > | null>;
 }
+
+interface ZoomIconProps {
+  targetImage: Image;
+}
+
+function ZoomIcon({ targetImage }: ZoomIconProps) {
+  return (
+    <Link key={targetImage.id} href={targetImage.url} target="_blank">
+      <IconButton
+        className={`absolute ${
+          isMobile ? 'bottom-[5px] right-[5px]' : 'bottom-[10px] right-[10px]'
+        } bg-gray-500 bg-opacity-10`}
+      >
+        <MagnifyingGlassIcon className="w-[20px] text-gray-200" />
+      </IconButton>
+    </Link>
+  );
+}
+
 function Arrow({ disabled, onClick, left }: CarouselArrowProps) {
   return (
     <IconButton
@@ -33,20 +57,19 @@ function Arrow({ disabled, onClick, left }: CarouselArrowProps) {
         disabled && 'hidden'
       } ${left ? 'left-[5px]' : 'left-[auto] right-[5px]'}`}
       disabled={disabled}
+      onClick={onClick}
     >
       {left ? (
         <ChevronLeftIcon
           height={30}
           width={30}
           className="text-gray-200 stroke-[1.5]"
-          onClick={onClick}
         />
       ) : (
         <ChevronRightIcon
           height={30}
           width={30}
           className="text-gray-200 stroke-[1.5]"
-          onClick={onClick}
         />
       )}
     </IconButton>
@@ -56,8 +79,8 @@ function Arrow({ disabled, onClick, left }: CarouselArrowProps) {
 function Navigation({ activeIndex, length, instanceRef }: NavigationProps) {
   if (length < 2) return null;
   return (
-    <div className="flex justify-center gap-2 z-50 mt-4 mb-4">
-      {/* <div className="absolute bottom-2 md:bottom-4 left-2/4 z-50 flex -translate-x-2/4 gap-2"> */}
+    // <div className="flex justify-center gap-2 z-50 mt-4 mb-4">
+    <div className="absolute bottom-2 md:bottom-4 left-2/4 z-50 flex -translate-x-2/4 gap-2">
       {_.range(length).map((index) => (
         <div
           role="presentation"
@@ -81,7 +104,7 @@ export default function ImageSlider({
   width,
   height,
 }: {
-  images: Image[] | undefined;
+  images: Image[];
   sizes: string;
   width: number;
   height: number;
@@ -99,53 +122,47 @@ export default function ImageSlider({
   });
 
   return (
-    <>
-      <div className="relative">
-        <div ref={sliderRef} className="keen-slider h-[320px] md:h-[520px]">
-          {_.map(images, (image, i) => (
-            <Link key={image.id + i} href={image.url} target="_blank">
-              <div
-                key={i}
-                // className="flex justify-center items-center overflow-hidden h-[320px] md:h-[520px] "
-                className="keen-slider__slide"
-                style={{
-                  position: 'relative',
-                  // objectFit: 'cover',
-                }}
-              >
-                <NextImage
-                  src={image.url}
-                  alt={image.name}
-                  width={width}
-                  height={height}
-                  // fill
-                  loading="lazy"
-                />
-              </div>
-            </Link>
-          ))}
-        </div>
-        {loaded && instanceRef.current && images && images.length > 1 && (
-          <div>
-            <Arrow
-              left
-              onClick={(e: any) =>
-                e.stopPropagation() || instanceRef.current?.prev()
-              }
-              disabled={activeIndex === 0}
+    <div className="relative">
+      <div ref={sliderRef} className="keen-slider h-[320px] md:h-[520px]">
+        {_.map(images, (image, i) => (
+          <div
+            key={i}
+            className="keen-slider__slide"
+            style={{
+              position: 'relative',
+            }}
+          >
+            <NextImage
+              src={image.url}
+              alt={image.name}
+              fill
+              style={{ objectFit: 'cover' }}
+              sizes="50vw"
             />
-            <Arrow
-              onClick={(e: any) =>
-                e.stopPropagation() || instanceRef.current?.next()
-              }
-              disabled={
-                activeIndex ===
-                instanceRef.current.track.details.slides.length - 1
-              }
-            />
+            <ZoomIcon targetImage={images[activeIndex]} />
           </div>
-        )}
+        ))}
       </div>
+      {loaded && instanceRef.current && images && images.length > 1 && (
+        <div>
+          <Arrow
+            left
+            onClick={(e: any) =>
+              e.stopPropagation() || instanceRef.current?.prev()
+            }
+            disabled={activeIndex === 0}
+          />
+          <Arrow
+            onClick={(e: any) =>
+              e.stopPropagation() || instanceRef.current?.next()
+            }
+            disabled={
+              activeIndex ===
+              instanceRef.current.track.details.slides.length - 1
+            }
+          />
+        </div>
+      )}
       {loaded && instanceRef.current && images && (
         <Navigation
           activeIndex={activeIndex}
@@ -153,6 +170,6 @@ export default function ImageSlider({
           instanceRef={instanceRef}
         />
       )}
-    </>
+    </div>
   );
 }

--- a/app/components/posts/post-detail.tsx
+++ b/app/components/posts/post-detail.tsx
@@ -110,8 +110,7 @@ export default function PostDetailCard({
                   <div className="text-[18px] font-normal">
                     {getPostTitle(post)}
                   </div>
-                  <div className="flex md:text-base justify-self-end  mt-[16px] items-center justify-between mb-[16px]">
-                    <span className="text-[12px] text-gray-600">거래가</span>
+                  <div className="flex md:text-base justify-self-end  mt-[4px] items-center mb-[16px]">
                     <span className="text-[18px] font-bold">
                       {convertPrice(getPrice(post))}
                     </span>

--- a/app/components/posts/post-detail.tsx
+++ b/app/components/posts/post-detail.tsx
@@ -21,6 +21,27 @@ export default function PostDetailCard({
 }) {
   const sizes = 'w-full h-full';
 
+  const convertPrice = (price: string): string => {
+    const numReg = /(\d+)/;
+    const matchReg = price.match(numReg);
+
+    if (!matchReg) {
+      return 'invalid ipt';
+    }
+    const amount = parseInt(matchReg[0], 10);
+
+    if (price.includes('천원')) {
+      return `${new Intl.NumberFormat('ko-KR').format(amount)}원`;
+    }
+    if (price.includes('만원')) {
+      return `${new Intl.NumberFormat('ko-KR').format(amount * 10000)}원`;
+    }
+    if (price.includes('백만원')) {
+      return `${new Intl.NumberFormat('ko-KR').format(amount * 1000000)}원`;
+    }
+    return `${new Intl.NumberFormat('ko-KR').format(amount)}원`;
+  };
+
   return (
     <Dialog
       open={open}
@@ -71,10 +92,10 @@ export default function PostDetailCard({
               height={760}
             />
           </div>
-          <div className="flex-none border-t-2 md:border-t-0 border-l-0 md:border-l-2 border-gray-100 line-break md:w-[50%] md:pl-[3.334%] pr-5 pl-5">
+          <div className="flex-none  border-l-0 md:border-l-2 border-gray-100 line-break md:w-[50%] md:pl-[3.334%] pr-5 pl-5">
             <div className="p-2 font-medium pl-0 pr-0">
               <div className="border-b-[1px]">
-                <div className="flex flex-row gap-2 text-sm md:text-base items-center">
+                <div className="flex flex-row gap-2 text-sm md:text-base items-center pl-2">
                   <UserProfile
                     user={post.user}
                     displayAvatar
@@ -85,12 +106,15 @@ export default function PostDetailCard({
                     {dayjs(post.createdAt).fromNow()}
                   </div>
                 </div>
-                <div className="p-2 flex flex-row gap-2 justify-between items-center">
-                  <div className="text-sm md:text-base font-semibold">
+                <div className="p-2 flex flex-col gap-2 mt-1">
+                  <div className="text-[18px] font-normal">
                     {getPostTitle(post)}
                   </div>
-                  <div className="flex-none text-sm md:text-base justify-self-end">
-                    {getPrice(post)}
+                  <div className="flex md:text-base justify-self-end  mt-[16px] items-center justify-between mb-[16px]">
+                    <span className="text-[12px] text-gray-600">거래가</span>
+                    <span className="text-[18px] font-bold">
+                      {convertPrice(getPrice(post))}
+                    </span>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
- 상세보기 화면 가격 금액표기 추가 

- 상세보기 화면에서 사진이 잘리게 되는 경우를 고려하여 zoom icon을 추가하였으나 배경 색상에 따라 아이콘이 가려지게 되는 경우가 생겼습니다. 

## 어떻게 해결했나요?
- 초기에 color-thief-react와 react-palette를 활용하여  해결하려고 했으나, 상세 이미지가 slider으로 이루어져있어 동적으로 업데이트가 간헐적으로 불가능 한 점, 그리고 아이콘이 위치한 영역의 색상 평균값을 통해 보색으로 가시성을 살리고자 했지만 모듈 버전 및 호환문제로 불가했습니다. 

- 아이콘 색상을 흰색 계열로 지정 후 아이콘 배경색 추가 및 투명도를 줌으로써 해결하였습니다. 

## 참고 자료