### PR TITLE
fix: solve popover z-index problem on detail page

### DIFF
--- a/components/base/image-slider.tsx
+++ b/components/base/image-slider.tsx
@@ -79,7 +79,7 @@ function Arrow({ disabled, onClick, left }: CarouselArrowProps) {
 function Navigation({ activeIndex, length, instanceRef }: NavigationProps) {
   if (length < 2) return null;
   return (
-    <div className="absolute bottom-2 md:bottom-4 left-2/4 z-50 flex -translate-x-2/4 gap-2">
+    <div className="absolute bottom-2 md:bottom-4 left-2/4 flex -translate-x-2/4 gap-2">
       {_.range(length).map((index) => (
         <div
           role="presentation"

--- a/components/base/navbar.tsx
+++ b/components/base/navbar.tsx
@@ -8,7 +8,7 @@ import Scrollbar from './scrollbar';
 export default function Navbar() {
   return (
     <Scrollbar upPosition="top-0">
-      <header className="w-full z-[41] bg-dark-500">
+      <header className="w-full bg-dark-500">
         <div className="max-w-5xl mx-auto flex items-center justify-between px-2 py-8 h-14">
           <Link href="/">
             <div className="flex flex-row items-center">

--- a/components/base/popper.tsx
+++ b/components/base/popper.tsx
@@ -19,7 +19,6 @@ export default function Popper({
   children,
 }: PopperProps) {
   const popperRef = useRef(null);
-
   useClickOutside(popperRef, handler);
 
   return (
@@ -29,6 +28,9 @@ export default function Popper({
       anchorEl={anchorEl}
       placement={placement}
       transition
+      sx={{
+        zIndex: 1300,
+      }}
     >
       {({ TransitionProps }) => (
         <Fade {...TransitionProps} timeout={delay}>

--- a/components/demands/demand-detail.tsx
+++ b/components/demands/demand-detail.tsx
@@ -29,7 +29,7 @@ export default function DemandDetail({
       sx={{
         top: isMobile ? '0px' : '56px',
       }}
-      className="max-w-screen z-50"
+      className="max-w-screen"
       slotProps={{
         backdrop: {
           sx: {
@@ -58,6 +58,7 @@ export default function DemandDetail({
             <XMarkIcon className="w-6 md:w-9 text-dark-200 hover:text-light-200 bg-dark-400 rounded-lg" />
           </IconButton>
         </div>
+
         {demand.images.length > 0 ? (
           <div className="flex flex-col md:flex-row gap-2 md:gap-14 justify-center">
             <div className="w-full md:w-[45%]">

--- a/components/offers/offer-detail.tsx
+++ b/components/offers/offer-detail.tsx
@@ -29,7 +29,7 @@ export default function OfferDetail({
       sx={{
         top: isMobile ? '0px' : '56px',
       }}
-      className="max-w-screen z-50"
+      className="max-w-screen"
       slotProps={{
         backdrop: {
           sx: {

--- a/components/offers/offer-preview.tsx
+++ b/components/offers/offer-preview.tsx
@@ -30,7 +30,7 @@ export default function OfferPreview({ offer }: Props) {
         className="flex flex-row w-full md:flex-col text-start"
       >
         {thumbnail && (
-          <div className="flex relative w-1/2 md:w-fit">
+          <div className="flex relative w-[38.5%] md:w-fit">
             <Thumbnail image={thumbnail} />
             <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
               <ChatBubbleOvalLeftIcon
@@ -41,11 +41,11 @@ export default function OfferPreview({ offer }: Props) {
             </div>
           </div>
         )}
-        <div className="w-1/2 md:w-full px-4 md:px-2">
-          <div className="text-xs md:text-sm font-medium py-2 text-light-200 h-fit md:h-12">
+        <div className="w-[61.5%] md:w-full px-4 md:px-2">
+          <div className="text-xs md:text-sm font-medium py-3 text-light-200 h-fit md:h-12">
             {offer.name}
           </div>
-          <div className="flex flex-row justify-between items-center py-2">
+          <div className="flex flex-row justify-between items-center py-3">
             <div className="flex-none text-sm md:text-base font-semibold">
               {getPrice(offer.price)}
             </div>

--- a/components/offers/offer-preview.tsx
+++ b/components/offers/offer-preview.tsx
@@ -32,7 +32,7 @@ export default function OfferPreview({ offer }: Props) {
         {thumbnail && (
           <div className="flex relative w-1/2 md:w-fit">
             <Thumbnail image={thumbnail} />
-            <div className="absolute top-1/2 left-1/2 z-50 -translate-x-1/2 -translate-y-1/2">
+            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
               <ChatBubbleOvalLeftIcon
                 color="white"
                 fill="white"

--- a/components/swaps/swap-detail.tsx
+++ b/components/swaps/swap-detail.tsx
@@ -30,7 +30,7 @@ export default function SwapDetail({
       sx={{
         top: isMobile ? '0px' : '56px',
       }}
-      className="max-w-screen z-50"
+      className="max-w-screen"
       slotProps={{
         backdrop: {
           sx: {

--- a/components/swaps/swap-preview.tsx
+++ b/components/swaps/swap-preview.tsx
@@ -33,7 +33,7 @@ export default function SwapPreview({ swap }: Props) {
         {thumbnail && (
           <div className="flex relative w-1/2 md:w-fit">
             <Thumbnail image={thumbnail} />
-            <div className="absolute top-1/2 left-1/2 z-50 -translate-x-1/2 -translate-y-1/2">
+            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
               <ChatBubbleOvalLeftIcon
                 color="white"
                 fill="white"

--- a/components/swaps/swap-preview.tsx
+++ b/components/swaps/swap-preview.tsx
@@ -31,7 +31,7 @@ export default function SwapPreview({ swap }: Props) {
         className="flex flex-row w-full md:flex-col text-start"
       >
         {thumbnail && (
-          <div className="flex relative w-1/2 md:w-fit">
+          <div className="flex relative w-[38.5%] md:w-fit">
             <Thumbnail image={thumbnail} />
             <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
               <ChatBubbleOvalLeftIcon
@@ -42,7 +42,7 @@ export default function SwapPreview({ swap }: Props) {
             </div>
           </div>
         )}
-        <div className="w-1/2 md:w-full px-4 md:px-2">
+        <div className="w-[61.5%] md:w-full px-4 md:px-2">
           <div className="text-xs md:text-sm font-medium py-2 text-light-200 h-fit md:h-12">
             <SwapName name0={swap.name0} name1={swap.name1} />
           </div>

--- a/components/users/user-profile.tsx
+++ b/components/users/user-profile.tsx
@@ -31,6 +31,7 @@ export default function UserProfile({
   const handlePopoverOpen = (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
   ) => {
+    event.stopPropagation();
     setAnchorEl(event.currentTarget);
   };
   const handlePopoverClose = () => {
@@ -71,7 +72,7 @@ export default function UserProfile({
         anchorEl={anchorEl}
         handler={handlePopoverClose}
       >
-        <div className="max-w-xs z-50 bg-white p-4 border rounded-lg drop-shadow-lg">
+        <div className="max-w-xs bg-light-200 p-4 rounded-lg">
           <div className="mb-2 flex items-center justify-between gap-4">
             <UserAvatar user={user} size="md" />
             {displayDM && (


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
detail page에서 user profile popover가 뒤에 위치하여 보이지 않음

## 어떻게 해결했나요?
tailwind의 className z-index로는 해결 X
-> MUIPopper sx zIndex 1300 설정

## 참고 자료
https://mui.com/system/getting-started/the-sx-prop/