### PR TITLE
feat: change previews using thumbnail, add guild feed in home root

### DIFF
--- a/app/g/[guildSlug]/market/demands/page.tsx
+++ b/app/g/[guildSlug]/market/demands/page.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { redirect } from 'next/navigation';
+import { guildVar } from '@/lib/apollo/cache';
+import { useReactiveVar } from '@apollo/client';
+
+function Page() {
+  const guild = useReactiveVar(guildVar);
+  if (!guild) return <div>null</div>;
+
+  const defaultCategorySlug = guild?.productCategories[0].slug;
+  return redirect(`demands/${defaultCategorySlug}`);
+}
+
+export default Page;

--- a/app/g/[guildSlug]/market/offers/page.tsx
+++ b/app/g/[guildSlug]/market/offers/page.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { redirect } from 'next/navigation';
+import { guildVar } from '@/lib/apollo/cache';
+import { useReactiveVar } from '@apollo/client';
+
+function Page() {
+  const guild = useReactiveVar(guildVar);
+  if (!guild) return <div>null</div>;
+
+  const defaultCategorySlug = guild?.productCategories[0].slug;
+  return redirect(`offers/${defaultCategorySlug}`);
+}
+
+export default Page;

--- a/app/g/[guildSlug]/market/swaps/page.tsx
+++ b/app/g/[guildSlug]/market/swaps/page.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { redirect } from 'next/navigation';
+import { guildVar } from '@/lib/apollo/cache';
+import { useReactiveVar } from '@apollo/client';
+
+function Page() {
+  const guild = useReactiveVar(guildVar);
+  if (!guild) return <div>null</div>;
+
+  const defaultCategorySlug = guild?.productCategories[0].slug;
+  return redirect(`swaps/${defaultCategorySlug}`);
+}
+
+export default Page;

--- a/app/g/[guildSlug]/page.tsx
+++ b/app/g/[guildSlug]/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { redirect } from 'next/navigation';
+import { guildVar } from '@/lib/apollo/cache';
+import { useReactiveVar } from '@apollo/client';
+
+export interface Props {
+  params: {
+    guildSlug: string;
+  };
+}
+
+function Page({ params: { guildSlug } }: Props) {
+  const guild = useReactiveVar(guildVar);
+  if (!guild) return <div>null</div>;
+
+  const defaultCategorySlug = guild?.productCategories[0].slug;
+  return redirect(`${guildSlug}/market/offers/${defaultCategorySlug}`);
+}
+
+export default Page;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,24 +1,13 @@
 'use client';
 
-import { redirect } from 'next/navigation';
-import { useFindGuildsQuery } from '@/generated/graphql';
-import { guildVar } from '@/lib/apollo/cache';
+import GuildFeed from '@/components/guilds/guild-feed';
 
 function Page() {
-  const { loading, error, data } = useFindGuildsQuery({
-    variables: {
-      take: 1,
-      skip: 0,
-    },
-  });
-  if (loading) return <div>Loading</div>;
-  if (error) return <div>Error</div>;
-
-  const guild = data?.findGuilds.edges[0].node;
-  guildVar(guild);
-  const defaultCategorySlug = guild?.productCategories[0].slug;
-
-  return redirect(`g/${guild?.slug}/market/offers/${defaultCategorySlug}`);
+  return (
+    <div className="mt-0">
+      <GuildFeed />
+    </div>
+  );
 }
 
 export default Page;

--- a/app/user/[username]/demands/[slug]/page.tsx
+++ b/app/user/[username]/demands/[slug]/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import DemandDetail from '@/components/demands/demand-detail';
-import { useFindDemandQuery } from '@/generated/graphql';
 
 function DemandPage({
   params: { slug },
@@ -10,17 +9,7 @@ function DemandPage({
     slug: string;
   };
 }) {
-  const { loading, error, data } = useFindDemandQuery({
-    variables: {
-      slug,
-    },
-  });
-
-  if (loading) return <div>Loading</div>;
-  if (error) return <div>Error</div>;
-  if (!data?.findDemand) return <div>null</div>;
-
-  return <DemandDetail demand={data.findDemand} />;
+  return <DemandDetail slug={slug} />;
 }
 
 export default DemandPage;

--- a/app/user/[username]/offers/[slug]/page.tsx
+++ b/app/user/[username]/offers/[slug]/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import OfferDetail from '@/components/offers/offer-detail';
-import { useFindOfferQuery } from '@/generated/graphql';
 
 function OfferPage({
   params: { slug },
@@ -10,17 +9,7 @@ function OfferPage({
     slug: string;
   };
 }) {
-  const { loading, error, data } = useFindOfferQuery({
-    variables: {
-      slug,
-    },
-  });
-
-  if (loading) return <div>Loading</div>;
-  if (error) return <div>Error</div>;
-  if (!data?.findOffer) return <div>null</div>;
-
-  return <OfferDetail offer={data.findOffer} />;
+  return <OfferDetail slug={slug} />;
 }
 
 export default OfferPage;

--- a/app/user/[username]/swaps/[slug]/page.tsx
+++ b/app/user/[username]/swaps/[slug]/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import SwapDetail from '@/components/swaps/swap-detail';
-import { useFindSwapQuery } from '@/generated/graphql';
 
 function SwapPage({
   params: { slug },
@@ -10,17 +9,7 @@ function SwapPage({
     slug: string;
   };
 }) {
-  const { loading, error, data } = useFindSwapQuery({
-    variables: {
-      slug,
-    },
-  });
-
-  if (loading) return <div>Loading</div>;
-  if (error) return <div>Error</div>;
-  if (!data?.findSwap) return <div>null</div>;
-
-  return <SwapDetail swap={data.findSwap} />;
+  return <SwapDetail slug={slug} />;
 }
 
 export default SwapPage;

--- a/components/base/navbar.tsx
+++ b/components/base/navbar.tsx
@@ -11,7 +11,7 @@ export default function Navbar() {
       <header className="w-full border-b-2 border-dark-600">
         <div className="max-w-5xl mx-auto flex items-center justify-between px-2 md:px-0 py-8 h-14">
           <Link href="/">
-            <div className="flex flex-row items-center">
+            <div className="flex flex-row gap-2 items-center">
               <Image
                 alt="guheyo logo"
                 src="/star/star-bg-purple-rounded.ico"

--- a/components/demands/demand-detail.tsx
+++ b/components/demands/demand-detail.tsx
@@ -3,13 +3,24 @@
 import dayjs from 'dayjs';
 import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 import remarkGfm from 'remark-gfm';
-import { DemandResponse } from '@/generated/graphql';
+import { useFindDemandQuery } from '@/generated/graphql';
 import { getPrice, truncateName } from '@/lib/formatter';
 import UserProfile from '../users/user-profile';
 import ImageSlider from '../base/image-slider';
 import PostDetail from '../posts/post-detail';
 
-export default function DemandDetail({ demand }: { demand: DemandResponse }) {
+export default function DemandDetail({ slug }: { slug: string }) {
+  const { loading, error, data } = useFindDemandQuery({
+    variables: {
+      slug,
+    },
+  });
+
+  if (loading) return <div>Loading</div>;
+  if (error) return <div>Error</div>;
+  if (!data?.findDemand) return <div>null</div>;
+  const demand = data.findDemand;
+
   const sizes = 'h-[360px] md:h-[524px]';
 
   if (demand.images.length > 0)

--- a/components/demands/demand-preview.tsx
+++ b/components/demands/demand-preview.tsx
@@ -4,12 +4,12 @@ import dayjs from 'dayjs';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { getPrice } from '@/lib/formatter';
-import { DemandResponse } from '@/generated/graphql';
+import { DemandPreviewFragment } from '@/generated/graphql';
 import DemandDetail from './demand-detail';
 import PostDialog from '../posts/post-dialog';
 
 interface Props {
-  demand: DemandResponse;
+  demand: DemandPreviewFragment;
 }
 
 export default function DemandPreview({ demand }: Props) {
@@ -58,7 +58,7 @@ export default function DemandPreview({ demand }: Props) {
           handleOpen={handleOpen}
           handleClose={handleClose}
         >
-          <DemandDetail demand={demand} />
+          <DemandDetail slug={demand.slug!} />
         </PostDialog>
       </div>
     </div>

--- a/components/guilds/guild-feed.tsx
+++ b/components/guilds/guild-feed.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useFindGuildPreviewsQuery } from '@/generated/graphql';
+import GuildPreview from './guild-preview';
+
+export default function GuildFeed() {
+  const { loading, error, data } = useFindGuildPreviewsQuery();
+  if (loading) return <div>Loading</div>;
+  if (error) return <div>Error</div>;
+  if (!data?.findGuildPreviews) return <div>null</div>;
+  const guilds = data.findGuildPreviews;
+
+  return (
+    <div className="grid grid-rows gap-12">
+      {guilds.map((guild) => (
+        <GuildPreview guild={guild} key={guild.slug} />
+      ))}
+    </div>
+  );
+}

--- a/components/guilds/guild-info.tsx
+++ b/components/guilds/guild-info.tsx
@@ -20,7 +20,7 @@ export default function GuildInfo({ slug }: { slug: string }) {
   guildVar(guild);
 
   return (
-    <div className="flex flex-row items-center gap-4 mx-2 md:mx-0">
+    <div className="flex flex-row items-center gap-4">
       <Image
         src={guild.icon!}
         width={isMobile ? 48 : 56}
@@ -28,7 +28,7 @@ export default function GuildInfo({ slug }: { slug: string }) {
         alt={`${guild.name} logo`}
         className="rounded-lg"
       />
-      <div className="text-star-500 text-lg md:text-xl font-bold ">{`g/${guild.name}`}</div>
+      <div className="text-star-500 text-lg md:text-xl font-bold">{`g/${guild.name}`}</div>
     </div>
   );
 }

--- a/components/guilds/guild-join-button.tsx
+++ b/components/guilds/guild-join-button.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import React from 'react';
+
+export default function GuildJoinButton({ slug }: { slug: string }) {
+  const router = useRouter();
+
+  const join = (): void => {
+    router.push(`g/${slug}`);
+  };
+
+  return (
+    <div className="inline-flex items-center">
+      <button
+        type="submit"
+        className="bg-eye-500 hover:bg-eye-400 text-sm font-bold p-2 rounded text-light-200"
+        onClick={() => join()}
+      >
+        입장
+      </button>
+    </div>
+  );
+}

--- a/components/guilds/guild-preview.tsx
+++ b/components/guilds/guild-preview.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import Link from 'next/link';
+import PlayCircleOutlineOutlinedIcon from '@mui/icons-material/PlayCircleOutlineOutlined';
+import { GuildPreviewFragment } from '@/generated/graphql';
+import GuildInfo from './guild-info';
+import DemandPreview from '../demands/demand-preview';
+import OfferPreview from '../offers/offer-preview';
+
+interface Props {
+  guild: GuildPreviewFragment;
+}
+
+export default function GuildPreview({ guild }: Props) {
+  return (
+    <div className="bg-dark-500 rounded-lg">
+      <div className="w-fit px-0 md:px-0 pt-4 mx-2 md:mx-0">
+        <Link href={`g/${guild.slug}/market`}>
+          <GuildInfo slug={guild.slug!} />
+        </Link>
+      </div>
+      <div className="flex flex-row justify-between gap-2 text-lg text-star-500 font-medium mx-2 md:mx-3 pt-5 pb-1">
+        <Link href={`g/${guild.slug}/market`}>
+          <span className="flex flex-row font-medium items-center gap-1">
+            {guild.name} 팝니다
+          </span>
+        </Link>
+      </div>
+      <div className="grid gap-x-0 md:gap-x-6 gap-y-1 lg:gap-y-14 grid-cols-1 md:grid-cols-3 lg:grid-cols-3 px-0 md:px-0">
+        {guild.offers.map((offer) => (
+          <OfferPreview key={offer.slug} offer={offer} />
+        ))}
+      </div>
+      <div className="flex justify-end text-base md:text-lg text-light-200 font-medium mx-2 md:mx-3 pt-2">
+        <Link href={`g/${guild.slug}/market`}>
+          <span className="flex flex-row font-medium items-center gap-1">
+            <PlayCircleOutlineOutlinedIcon fontSize="medium" />
+            판매 채널 입장
+          </span>
+        </Link>
+      </div>
+      <div className="text-lg text-star-500 font-medium mx-2 md:mx-3 pt-5 pb-1">
+        <Link href={`g/${guild.slug}/market`}>{guild.name} 삽니다</Link>
+      </div>
+      <div className="grid gap-x-0 md:gap-x-6 gap-y-1 lg:gap-y-14 grid-cols-1 md:grid-cols-3 lg:grid-cols-3 px-0 md:px-0">
+        {guild.demands.map((demand) => (
+          <DemandPreview key={demand.slug} demand={demand} />
+        ))}
+      </div>
+      <div className="flex justify-end text-base md:text-lg text-light-200 font-medium mx-2 md:mx-3 pt-2">
+        <Link href={`g/${guild.slug}/market`}>
+          <span className="flex flex-row font-medium items-center gap-1">
+            <PlayCircleOutlineOutlinedIcon fontSize="medium" />
+            구매 채널 입장
+          </span>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/guilds/guild-preview.tsx
+++ b/components/guilds/guild-preview.tsx
@@ -15,12 +15,12 @@ export default function GuildPreview({ guild }: Props) {
   return (
     <div className="bg-dark-500 rounded-lg">
       <div className="w-fit px-0 md:px-0 pt-4 mx-2 md:mx-0">
-        <Link href={`g/${guild.slug}/market`}>
+        <Link href={`g/${guild.slug}`}>
           <GuildInfo slug={guild.slug!} />
         </Link>
       </div>
       <div className="flex flex-row justify-between gap-2 text-lg text-star-500 font-medium mx-2 md:mx-3 pt-5 pb-1">
-        <Link href={`g/${guild.slug}/market`}>
+        <Link href={`g/${guild.slug}/market/offers`}>
           <span className="flex flex-row font-medium items-center gap-1">
             {guild.name} 팝니다
           </span>
@@ -32,7 +32,7 @@ export default function GuildPreview({ guild }: Props) {
         ))}
       </div>
       <div className="flex justify-end text-base md:text-lg text-light-200 font-medium mx-2 md:mx-3 pt-2">
-        <Link href={`g/${guild.slug}/market`}>
+        <Link href={`g/${guild.slug}/market/offers`}>
           <span className="flex flex-row font-medium items-center gap-1">
             <PlayCircleOutlineOutlinedIcon fontSize="medium" />
             판매 채널 입장
@@ -40,7 +40,7 @@ export default function GuildPreview({ guild }: Props) {
         </Link>
       </div>
       <div className="text-lg text-star-500 font-medium mx-2 md:mx-3 pt-5 pb-1">
-        <Link href={`g/${guild.slug}/market`}>{guild.name} 삽니다</Link>
+        <Link href={`g/${guild.slug}/market/demands`}>{guild.name} 삽니다</Link>
       </div>
       <div className="grid gap-x-0 md:gap-x-6 gap-y-1 lg:gap-y-14 grid-cols-1 md:grid-cols-3 lg:grid-cols-3 px-0 md:px-0">
         {guild.demands.map((demand) => (
@@ -48,7 +48,7 @@ export default function GuildPreview({ guild }: Props) {
         ))}
       </div>
       <div className="flex justify-end text-base md:text-lg text-light-200 font-medium mx-2 md:mx-3 pt-2">
-        <Link href={`g/${guild.slug}/market`}>
+        <Link href={`g/${guild.slug}/market/demands`}>
           <span className="flex flex-row font-medium items-center gap-1">
             <PlayCircleOutlineOutlinedIcon fontSize="medium" />
             구매 채널 입장

--- a/components/guilds/guild-preview.tsx
+++ b/components/guilds/guild-preview.tsx
@@ -6,6 +6,7 @@ import { GuildPreviewFragment } from '@/generated/graphql';
 import GuildInfo from './guild-info';
 import DemandPreview from '../demands/demand-preview';
 import OfferPreview from '../offers/offer-preview';
+import GuildJoinButton from './guild-join-button';
 
 interface Props {
   guild: GuildPreviewFragment;
@@ -14,12 +15,13 @@ interface Props {
 export default function GuildPreview({ guild }: Props) {
   return (
     <div className="bg-dark-500 rounded-lg">
-      <div className="w-fit px-0 md:px-0 pt-4 mx-2 md:mx-0">
+      <div className="flex flex-row gap-6 justify-between w-fit px-0 md:px-0 pt-4 mx-2 md:mx-0">
         <Link href={`g/${guild.slug}`}>
           <GuildInfo slug={guild.slug!} />
         </Link>
+        <GuildJoinButton slug={guild.slug!} />
       </div>
-      <div className="flex flex-row justify-between gap-2 text-lg text-star-500 font-medium mx-2 md:mx-3 pt-5 pb-1">
+      <div className="text-lg text-star-500 font-medium mx-2 md:mx-3 pt-5 pb-1">
         <Link href={`g/${guild.slug}/market/offers`}>
           <span className="flex flex-row font-medium items-center gap-1">
             {guild.name} 팝니다
@@ -35,7 +37,7 @@ export default function GuildPreview({ guild }: Props) {
         <Link href={`g/${guild.slug}/market/offers`}>
           <span className="flex flex-row font-medium items-center gap-1">
             <PlayCircleOutlineOutlinedIcon fontSize="medium" />
-            판매 채널 입장
+            판매 채널
           </span>
         </Link>
       </div>
@@ -51,7 +53,7 @@ export default function GuildPreview({ guild }: Props) {
         <Link href={`g/${guild.slug}/market/demands`}>
           <span className="flex flex-row font-medium items-center gap-1">
             <PlayCircleOutlineOutlinedIcon fontSize="medium" />
-            구매 채널 입장
+            구매 채널
           </span>
         </Link>
       </div>

--- a/components/offers/offer-detail.tsx
+++ b/components/offers/offer-detail.tsx
@@ -3,13 +3,24 @@
 import dayjs from 'dayjs';
 import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 import remarkGfm from 'remark-gfm';
-import { OfferResponse } from '@/generated/graphql';
+import { useFindOfferQuery } from '@/generated/graphql';
 import { getPrice } from '@/lib/formatter';
 import UserProfile from '../users/user-profile';
 import ImageSlider from '../base/image-slider';
 import PostDetail from '../posts/post-detail';
 
-export default function OfferDetail({ offer }: { offer: OfferResponse }) {
+export default function OfferDetail({ slug }: { slug: string }) {
+  const { loading, error, data } = useFindOfferQuery({
+    variables: {
+      slug,
+    },
+  });
+
+  if (loading) return <div>Loading</div>;
+  if (error) return <div>Error</div>;
+  if (!data?.findOffer) return <div>null</div>;
+  const offer = data.findOffer;
+
   const sizes = 'h-[360px] md:h-[524px]';
 
   return (

--- a/components/offers/offer-preview.tsx
+++ b/components/offers/offer-preview.tsx
@@ -6,18 +6,18 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { ChatBubbleOvalLeftIcon } from '@heroicons/react/24/outline';
 import { getPrice, truncateName } from '@/lib/formatter';
-import { OfferResponse, UserImageResponse } from '@/generated/graphql';
+import { OfferPreviewFragment } from '@/generated/graphql';
 import Thumbnail from '../base/thumbnail';
 import PostDialog from '../posts/post-dialog';
 import OfferDetail from './offer-detail';
 
 interface Props {
-  offer: OfferResponse;
+  offer: OfferPreviewFragment;
 }
 
 export default function OfferPreview({ offer }: Props) {
   const router = useRouter();
-  const thumbnail: UserImageResponse = _.get(offer.images, '[0]')!;
+  const { thumbnail } = offer;
   const [open, setOpen] = useState(false);
 
   const handleOpen = () => {
@@ -74,7 +74,7 @@ export default function OfferPreview({ offer }: Props) {
           handleOpen={handleOpen}
           handleClose={handleClose}
         >
-          <OfferDetail offer={offer} />
+          <OfferDetail slug={offer.slug!} />
         </PostDialog>
       </div>
     </div>

--- a/components/swaps/swap-detail.tsx
+++ b/components/swaps/swap-detail.tsx
@@ -3,14 +3,25 @@
 import dayjs from 'dayjs';
 import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 import remarkGfm from 'remark-gfm';
-import { SwapResponse } from '@/generated/graphql';
+import { useFindSwapQuery } from '@/generated/graphql';
 import { getPrice } from '@/lib/formatter';
 import UserProfile from '../users/user-profile';
 import ImageSlider from '../base/image-slider';
 import SwapName from './swap-name';
 import PostDetail from '../posts/post-detail';
 
-export default function SwapDetail({ swap }: { swap: SwapResponse }) {
+export default function SwapDetail({ slug }: { slug: string }) {
+  const { loading, error, data } = useFindSwapQuery({
+    variables: {
+      slug,
+    },
+  });
+
+  if (loading) return <div>Loading</div>;
+  if (error) return <div>Error</div>;
+  if (!data?.findSwap) return <div>null</div>;
+  const swap = data.findSwap;
+
   const sizes = 'h-[360px] md:h-[524px]';
 
   return (

--- a/components/swaps/swap-preview.tsx
+++ b/components/swaps/swap-preview.tsx
@@ -6,19 +6,19 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { ChatBubbleOvalLeftIcon } from '@heroicons/react/24/outline';
 import { getPrice } from '@/lib/formatter';
-import { SwapResponse, UserImageResponse } from '@/generated/graphql';
+import { SwapPreviewFragment } from '@/generated/graphql';
 import SwapDetail from './swap-detail';
 import Thumbnail from '../base/thumbnail';
 import SwapName from './swap-name';
 import PostDialog from '../posts/post-dialog';
 
 interface Props {
-  swap: SwapResponse;
+  swap: SwapPreviewFragment;
 }
 
 export default function SwapPreview({ swap }: Props) {
   const router = useRouter();
-  const thumbnail: UserImageResponse = _.get(swap.images, '[0]')!;
+  const { thumbnail } = swap;
   const [open, setOpen] = useState(false);
 
   const handleOpen = () => {
@@ -75,7 +75,7 @@ export default function SwapPreview({ swap }: Props) {
           handleOpen={handleOpen}
           handleClose={handleClose}
         >
-          <SwapDetail swap={swap} />
+          <SwapDetail slug={swap.slug!} />
         </PostDialog>
       </div>
     </div>

--- a/generated/graphql.ts
+++ b/generated/graphql.ts
@@ -261,6 +261,18 @@ export type DisconnectRolesInput = {
   roleIds: Array<Scalars['ID']['input']>;
 };
 
+export type GuildPreviewResponse = {
+  __typename?: 'GuildPreviewResponse';
+  demands: Array<DemandResponse>;
+  description?: Maybe<Scalars['String']['output']>;
+  icon?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  offers: Array<OfferResponse>;
+  position?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+};
+
 export type GuildResponse = {
   __typename?: 'GuildResponse';
   description?: Maybe<Scalars['String']['output']>;
@@ -565,6 +577,7 @@ export type OfferResponse = {
   slug?: Maybe<Scalars['String']['output']>;
   source: Scalars['String']['output'];
   status: Scalars['String']['output'];
+  thumbnail?: Maybe<UserImageResponse>;
   updatedAt: Scalars['DateTime']['output'];
 };
 
@@ -643,6 +656,7 @@ export type Query = {
   findDemands: PaginatedDemandsResponse;
   findGuild?: Maybe<GuildResponse>;
   findGuildById?: Maybe<GuildResponse>;
+  findGuildPreviews: Array<GuildPreviewResponse>;
   findGuilds: PaginatedGuildsResponse;
   findMemberByUserAndGuild?: Maybe<MemberWithRolesResponse>;
   findMyUserById?: Maybe<MyUserResponse>;
@@ -867,6 +881,7 @@ export type SwapResponse = {
   slug?: Maybe<Scalars['String']['output']>;
   source: Scalars['String']['output'];
   status: Scalars['String']['output'];
+  thumbnail?: Maybe<UserImageResponse>;
   updatedAt: Scalars['DateTime']['output'];
 };
 
@@ -1005,6 +1020,8 @@ export type UserResponseEdge = {
 
 export type DemandFragment = { __typename?: 'DemandResponse', id: string, createdAt: any, updatedAt: any, name: string, slug?: string | null, description?: string | null, price: number, priceCurrency: string, businessFunction: string, status: string, source: string, guildId: string, productCategoryId: string, brandId?: string | null, images: Array<{ __typename?: 'UserImageResponse', id: string, createdAt: any, updatedAt: any, name: string, url: string, contentType?: string | null, description?: string | null, height?: number | null, width?: number | null, position: number, type: string, refId: string, userId: string, source: string }>, buyer: { __typename?: 'AuthorResponse', id: string, createdAt: any, username: string, avatarURL?: string | null, bot: boolean, socialAccounts: Array<{ __typename?: 'SocialAccountWithoutAuthResponse', id: string, createdAt: any, provider: string, socialId: string, userId: string }>, members: Array<{ __typename?: 'MemberWithRolesResponse', id: string, createdAt: any, userId: string, guildId: string, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, guildId: string }> }> } };
 
+export type DemandPreviewFragment = { __typename?: 'DemandResponse', id: string, createdAt: any, updatedAt: any, name: string, slug?: string | null, price: number, priceCurrency: string, businessFunction: string, status: string, source: string, guildId: string, productCategoryId: string, brandId?: string | null, buyer: { __typename?: 'AuthorResponse', username: string } };
+
 export type FindDemandsQueryVariables = Exact<{
   productCategoryId: Scalars['ID']['input'];
   cursor?: InputMaybe<Scalars['ID']['input']>;
@@ -1013,7 +1030,7 @@ export type FindDemandsQueryVariables = Exact<{
 }>;
 
 
-export type FindDemandsQuery = { __typename?: 'Query', findDemands: { __typename?: 'PaginatedDemandsResponse', edges: Array<{ __typename?: 'DemandResponseEdge', cursor: string, node: { __typename?: 'DemandResponse', id: string, createdAt: any, updatedAt: any, name: string, slug?: string | null, description?: string | null, price: number, priceCurrency: string, businessFunction: string, status: string, source: string, guildId: string, productCategoryId: string, brandId?: string | null, images: Array<{ __typename?: 'UserImageResponse', id: string, createdAt: any, updatedAt: any, name: string, url: string, contentType?: string | null, description?: string | null, height?: number | null, width?: number | null, position: number, type: string, refId: string, userId: string, source: string }>, buyer: { __typename?: 'AuthorResponse', id: string, createdAt: any, username: string, avatarURL?: string | null, bot: boolean, socialAccounts: Array<{ __typename?: 'SocialAccountWithoutAuthResponse', id: string, createdAt: any, provider: string, socialId: string, userId: string }>, members: Array<{ __typename?: 'MemberWithRolesResponse', id: string, createdAt: any, userId: string, guildId: string, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, guildId: string }> }> } } }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } } };
+export type FindDemandsQuery = { __typename?: 'Query', findDemands: { __typename?: 'PaginatedDemandsResponse', edges: Array<{ __typename?: 'DemandResponseEdge', cursor: string, node: { __typename?: 'DemandResponse', id: string, createdAt: any, updatedAt: any, name: string, slug?: string | null, price: number, priceCurrency: string, businessFunction: string, status: string, source: string, guildId: string, productCategoryId: string, brandId?: string | null, buyer: { __typename?: 'AuthorResponse', username: string } } }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } } };
 
 export type FindDemandByIdQueryVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -1031,6 +1048,8 @@ export type FindDemandQuery = { __typename?: 'Query', findDemand?: { __typename?
 
 export type GuildFragment = { __typename?: 'GuildResponse', id: string, name: string, slug?: string | null, description?: string | null, icon?: string | null, position?: number | null, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, guildId: string }>, productCategories: Array<{ __typename?: 'ProductCategoryResponse', id: string, name: string, slug?: string | null, position?: number | null }>, postCategories: Array<{ __typename?: 'PostCategoryResponse', id: string, name: string, slug?: string | null, description?: string | null, position?: number | null }> };
 
+export type GuildPreviewFragment = { __typename?: 'GuildPreviewResponse', id: string, name: string, slug?: string | null, description?: string | null, icon?: string | null, position?: number | null, offers: Array<{ __typename?: 'OfferResponse', id: string, createdAt: any, updatedAt: any, name: string, slug?: string | null, price: number, priceCurrency: string, businessFunction: string, status: string, source: string, guildId: string, productCategoryId: string, brandId?: string | null, thumbnail?: { __typename?: 'UserImageResponse', id: string, createdAt: any, updatedAt: any, name: string, url: string, contentType?: string | null, description?: string | null, height?: number | null, width?: number | null, position: number, type: string, refId: string, userId: string, source: string } | null, seller: { __typename?: 'AuthorResponse', username: string } }>, demands: Array<{ __typename?: 'DemandResponse', id: string, createdAt: any, updatedAt: any, name: string, slug?: string | null, price: number, priceCurrency: string, businessFunction: string, status: string, source: string, guildId: string, productCategoryId: string, brandId?: string | null, buyer: { __typename?: 'AuthorResponse', username: string } }> };
+
 export type FindGuildsQueryVariables = Exact<{
   cursor?: InputMaybe<Scalars['ID']['input']>;
   skip?: Scalars['Int']['input'];
@@ -1047,7 +1066,14 @@ export type FindGuildQueryVariables = Exact<{
 
 export type FindGuildQuery = { __typename?: 'Query', findGuild?: { __typename?: 'GuildResponse', id: string, name: string, slug?: string | null, description?: string | null, icon?: string | null, position?: number | null, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, guildId: string }>, productCategories: Array<{ __typename?: 'ProductCategoryResponse', id: string, name: string, slug?: string | null, position?: number | null }>, postCategories: Array<{ __typename?: 'PostCategoryResponse', id: string, name: string, slug?: string | null, description?: string | null, position?: number | null }> } | null };
 
+export type FindGuildPreviewsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type FindGuildPreviewsQuery = { __typename?: 'Query', findGuildPreviews: Array<{ __typename?: 'GuildPreviewResponse', id: string, name: string, slug?: string | null, description?: string | null, icon?: string | null, position?: number | null, offers: Array<{ __typename?: 'OfferResponse', id: string, createdAt: any, updatedAt: any, name: string, slug?: string | null, price: number, priceCurrency: string, businessFunction: string, status: string, source: string, guildId: string, productCategoryId: string, brandId?: string | null, thumbnail?: { __typename?: 'UserImageResponse', id: string, createdAt: any, updatedAt: any, name: string, url: string, contentType?: string | null, description?: string | null, height?: number | null, width?: number | null, position: number, type: string, refId: string, userId: string, source: string } | null, seller: { __typename?: 'AuthorResponse', username: string } }>, demands: Array<{ __typename?: 'DemandResponse', id: string, createdAt: any, updatedAt: any, name: string, slug?: string | null, price: number, priceCurrency: string, businessFunction: string, status: string, source: string, guildId: string, productCategoryId: string, brandId?: string | null, buyer: { __typename?: 'AuthorResponse', username: string } }> }> };
+
 export type OfferFragment = { __typename?: 'OfferResponse', id: string, createdAt: any, updatedAt: any, name: string, slug?: string | null, description?: string | null, price: number, priceCurrency: string, businessFunction: string, status: string, source: string, guildId: string, productCategoryId: string, brandId?: string | null, images: Array<{ __typename?: 'UserImageResponse', id: string, createdAt: any, updatedAt: any, name: string, url: string, contentType?: string | null, description?: string | null, height?: number | null, width?: number | null, position: number, type: string, refId: string, userId: string, source: string }>, seller: { __typename?: 'AuthorResponse', id: string, createdAt: any, username: string, avatarURL?: string | null, bot: boolean, socialAccounts: Array<{ __typename?: 'SocialAccountWithoutAuthResponse', id: string, createdAt: any, provider: string, socialId: string, userId: string }>, members: Array<{ __typename?: 'MemberWithRolesResponse', id: string, createdAt: any, userId: string, guildId: string, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, guildId: string }> }> } };
+
+export type OfferPreviewFragment = { __typename?: 'OfferResponse', id: string, createdAt: any, updatedAt: any, name: string, slug?: string | null, price: number, priceCurrency: string, businessFunction: string, status: string, source: string, guildId: string, productCategoryId: string, brandId?: string | null, thumbnail?: { __typename?: 'UserImageResponse', id: string, createdAt: any, updatedAt: any, name: string, url: string, contentType?: string | null, description?: string | null, height?: number | null, width?: number | null, position: number, type: string, refId: string, userId: string, source: string } | null, seller: { __typename?: 'AuthorResponse', username: string } };
 
 export type FindOffersQueryVariables = Exact<{
   productCategoryId: Scalars['ID']['input'];
@@ -1057,7 +1083,7 @@ export type FindOffersQueryVariables = Exact<{
 }>;
 
 
-export type FindOffersQuery = { __typename?: 'Query', findOffers: { __typename?: 'PaginatedOffersResponse', edges: Array<{ __typename?: 'OfferResponseEdge', cursor: string, node: { __typename?: 'OfferResponse', id: string, createdAt: any, updatedAt: any, name: string, slug?: string | null, description?: string | null, price: number, priceCurrency: string, businessFunction: string, status: string, source: string, guildId: string, productCategoryId: string, brandId?: string | null, images: Array<{ __typename?: 'UserImageResponse', id: string, createdAt: any, updatedAt: any, name: string, url: string, contentType?: string | null, description?: string | null, height?: number | null, width?: number | null, position: number, type: string, refId: string, userId: string, source: string }>, seller: { __typename?: 'AuthorResponse', id: string, createdAt: any, username: string, avatarURL?: string | null, bot: boolean, socialAccounts: Array<{ __typename?: 'SocialAccountWithoutAuthResponse', id: string, createdAt: any, provider: string, socialId: string, userId: string }>, members: Array<{ __typename?: 'MemberWithRolesResponse', id: string, createdAt: any, userId: string, guildId: string, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, guildId: string }> }> } } }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } } };
+export type FindOffersQuery = { __typename?: 'Query', findOffers: { __typename?: 'PaginatedOffersResponse', edges: Array<{ __typename?: 'OfferResponseEdge', cursor: string, node: { __typename?: 'OfferResponse', id: string, createdAt: any, updatedAt: any, name: string, slug?: string | null, price: number, priceCurrency: string, businessFunction: string, status: string, source: string, guildId: string, productCategoryId: string, brandId?: string | null, thumbnail?: { __typename?: 'UserImageResponse', id: string, createdAt: any, updatedAt: any, name: string, url: string, contentType?: string | null, description?: string | null, height?: number | null, width?: number | null, position: number, type: string, refId: string, userId: string, source: string } | null, seller: { __typename?: 'AuthorResponse', username: string } } }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } } };
 
 export type FindOfferByIdQueryVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -1124,6 +1150,8 @@ export type DeleteSocialAccountByProviderMutation = { __typename?: 'Mutation', d
 
 export type SwapFragment = { __typename?: 'SwapResponse', id: string, createdAt: any, updatedAt: any, slug?: string | null, name0: string, name1: string, description0?: string | null, description1?: string | null, price: number, priceCurrency: string, businessFunction: string, status: string, source: string, guildId: string, productCategoryId: string, brandId?: string | null, images: Array<{ __typename?: 'UserImageResponse', id: string, createdAt: any, updatedAt: any, name: string, url: string, contentType?: string | null, description?: string | null, height?: number | null, width?: number | null, position: number, type: string, refId: string, userId: string, source: string }>, proposer: { __typename?: 'AuthorResponse', id: string, createdAt: any, username: string, avatarURL?: string | null, bot: boolean, socialAccounts: Array<{ __typename?: 'SocialAccountWithoutAuthResponse', id: string, createdAt: any, provider: string, socialId: string, userId: string }>, members: Array<{ __typename?: 'MemberWithRolesResponse', id: string, createdAt: any, userId: string, guildId: string, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, guildId: string }> }> } };
 
+export type SwapPreviewFragment = { __typename?: 'SwapResponse', id: string, createdAt: any, updatedAt: any, slug?: string | null, name0: string, name1: string, price: number, priceCurrency: string, businessFunction: string, status: string, source: string, guildId: string, productCategoryId: string, brandId?: string | null, thumbnail?: { __typename?: 'UserImageResponse', id: string, createdAt: any, updatedAt: any, name: string, url: string, contentType?: string | null, description?: string | null, height?: number | null, width?: number | null, position: number, type: string, refId: string, userId: string, source: string } | null, proposer: { __typename?: 'AuthorResponse', username: string } };
+
 export type FindSwapsQueryVariables = Exact<{
   productCategoryId: Scalars['ID']['input'];
   cursor?: InputMaybe<Scalars['ID']['input']>;
@@ -1132,7 +1160,7 @@ export type FindSwapsQueryVariables = Exact<{
 }>;
 
 
-export type FindSwapsQuery = { __typename?: 'Query', findSwaps: { __typename?: 'PaginatedSwapsResponse', edges: Array<{ __typename?: 'SwapResponseEdge', cursor: string, node: { __typename?: 'SwapResponse', id: string, createdAt: any, updatedAt: any, slug?: string | null, name0: string, name1: string, description0?: string | null, description1?: string | null, price: number, priceCurrency: string, businessFunction: string, status: string, source: string, guildId: string, productCategoryId: string, brandId?: string | null, images: Array<{ __typename?: 'UserImageResponse', id: string, createdAt: any, updatedAt: any, name: string, url: string, contentType?: string | null, description?: string | null, height?: number | null, width?: number | null, position: number, type: string, refId: string, userId: string, source: string }>, proposer: { __typename?: 'AuthorResponse', id: string, createdAt: any, username: string, avatarURL?: string | null, bot: boolean, socialAccounts: Array<{ __typename?: 'SocialAccountWithoutAuthResponse', id: string, createdAt: any, provider: string, socialId: string, userId: string }>, members: Array<{ __typename?: 'MemberWithRolesResponse', id: string, createdAt: any, userId: string, guildId: string, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, guildId: string }> }> } } }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } } };
+export type FindSwapsQuery = { __typename?: 'Query', findSwaps: { __typename?: 'PaginatedSwapsResponse', edges: Array<{ __typename?: 'SwapResponseEdge', cursor: string, node: { __typename?: 'SwapResponse', id: string, createdAt: any, updatedAt: any, slug?: string | null, name0: string, name1: string, price: number, priceCurrency: string, businessFunction: string, status: string, source: string, guildId: string, productCategoryId: string, brandId?: string | null, thumbnail?: { __typename?: 'UserImageResponse', id: string, createdAt: any, updatedAt: any, name: string, url: string, contentType?: string | null, description?: string | null, height?: number | null, width?: number | null, position: number, type: string, refId: string, userId: string, source: string } | null, proposer: { __typename?: 'AuthorResponse', username: string } } }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } } };
 
 export type FindSwapByIdQueryVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -1332,6 +1360,66 @@ export const GuildFragmentDoc = gql`
   }
 }
     `;
+export const OfferPreviewFragmentDoc = gql`
+    fragment offerPreview on OfferResponse {
+  id
+  createdAt
+  updatedAt
+  name
+  slug
+  price
+  priceCurrency
+  businessFunction
+  status
+  source
+  thumbnail {
+    ...image
+  }
+  guildId
+  productCategoryId
+  seller {
+    username
+  }
+  brandId
+}
+    ${ImageFragmentDoc}`;
+export const DemandPreviewFragmentDoc = gql`
+    fragment demandPreview on DemandResponse {
+  id
+  createdAt
+  updatedAt
+  name
+  slug
+  price
+  priceCurrency
+  businessFunction
+  status
+  source
+  guildId
+  productCategoryId
+  buyer {
+    username
+  }
+  brandId
+}
+    `;
+export const GuildPreviewFragmentDoc = gql`
+    fragment guildPreview on GuildPreviewResponse {
+  id
+  name
+  slug
+  description
+  icon
+  position
+  offers {
+    ...offerPreview
+  }
+  demands {
+    ...demandPreview
+  }
+}
+    ${OfferPreviewFragmentDoc}
+${DemandPreviewFragmentDoc}`;
 export const SellerFragmentDoc = gql`
     fragment seller on AuthorResponse {
   id
@@ -1423,6 +1511,30 @@ export const SwapFragmentDoc = gql`
 }
     ${ImageFragmentDoc}
 ${ProposerFragmentDoc}`;
+export const SwapPreviewFragmentDoc = gql`
+    fragment swapPreview on SwapResponse {
+  id
+  createdAt
+  updatedAt
+  slug
+  name0
+  name1
+  price
+  priceCurrency
+  businessFunction
+  status
+  source
+  thumbnail {
+    ...image
+  }
+  guildId
+  productCategoryId
+  proposer {
+    username
+  }
+  brandId
+}
+    ${ImageFragmentDoc}`;
 export const UserFragmentDoc = gql`
     fragment user on UserResponse {
   id
@@ -1476,7 +1588,7 @@ export const FindDemandsDocument = gql`
   ) {
     edges {
       node {
-        ...demand
+        ...demandPreview
       }
       cursor
     }
@@ -1486,7 +1598,7 @@ export const FindDemandsDocument = gql`
     }
   }
 }
-    ${DemandFragmentDoc}`;
+    ${DemandPreviewFragmentDoc}`;
 
 /**
  * __useFindDemandsQuery__
@@ -1692,6 +1804,45 @@ export type FindGuildQueryHookResult = ReturnType<typeof useFindGuildQuery>;
 export type FindGuildLazyQueryHookResult = ReturnType<typeof useFindGuildLazyQuery>;
 export type FindGuildSuspenseQueryHookResult = ReturnType<typeof useFindGuildSuspenseQuery>;
 export type FindGuildQueryResult = Apollo.QueryResult<FindGuildQuery, FindGuildQueryVariables>;
+export const FindGuildPreviewsDocument = gql`
+    query findGuildPreviews {
+  findGuildPreviews {
+    ...guildPreview
+  }
+}
+    ${GuildPreviewFragmentDoc}`;
+
+/**
+ * __useFindGuildPreviewsQuery__
+ *
+ * To run a query within a React component, call `useFindGuildPreviewsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useFindGuildPreviewsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useFindGuildPreviewsQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useFindGuildPreviewsQuery(baseOptions?: Apollo.QueryHookOptions<FindGuildPreviewsQuery, FindGuildPreviewsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<FindGuildPreviewsQuery, FindGuildPreviewsQueryVariables>(FindGuildPreviewsDocument, options);
+      }
+export function useFindGuildPreviewsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<FindGuildPreviewsQuery, FindGuildPreviewsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<FindGuildPreviewsQuery, FindGuildPreviewsQueryVariables>(FindGuildPreviewsDocument, options);
+        }
+export function useFindGuildPreviewsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindGuildPreviewsQuery, FindGuildPreviewsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<FindGuildPreviewsQuery, FindGuildPreviewsQueryVariables>(FindGuildPreviewsDocument, options);
+        }
+export type FindGuildPreviewsQueryHookResult = ReturnType<typeof useFindGuildPreviewsQuery>;
+export type FindGuildPreviewsLazyQueryHookResult = ReturnType<typeof useFindGuildPreviewsLazyQuery>;
+export type FindGuildPreviewsSuspenseQueryHookResult = ReturnType<typeof useFindGuildPreviewsSuspenseQuery>;
+export type FindGuildPreviewsQueryResult = Apollo.QueryResult<FindGuildPreviewsQuery, FindGuildPreviewsQueryVariables>;
 export const FindOffersDocument = gql`
     query findOffers($productCategoryId: ID!, $cursor: ID, $skip: Int!, $take: Int!) {
   findOffers(
@@ -1702,7 +1853,7 @@ export const FindOffersDocument = gql`
   ) {
     edges {
       node {
-        ...offer
+        ...offerPreview
       }
       cursor
     }
@@ -1712,7 +1863,7 @@ export const FindOffersDocument = gql`
     }
   }
 }
-    ${OfferFragmentDoc}`;
+    ${OfferPreviewFragmentDoc}`;
 
 /**
  * __useFindOffersQuery__
@@ -2035,7 +2186,7 @@ export const FindSwapsDocument = gql`
   ) {
     edges {
       node {
-        ...swap
+        ...swapPreview
       }
       cursor
     }
@@ -2045,7 +2196,7 @@ export const FindSwapsDocument = gql`
     }
   }
 }
-    ${SwapFragmentDoc}`;
+    ${SwapPreviewFragmentDoc}`;
 
 /**
  * __useFindSwapsQuery__

--- a/lib/graphql/demand.graphql
+++ b/lib/graphql/demand.graphql
@@ -21,6 +21,25 @@ fragment demand on DemandResponse {
   brandId
 }
 
+fragment demandPreview on DemandResponse {
+  id
+  createdAt
+  updatedAt
+  name
+  slug
+  price
+  priceCurrency
+  businessFunction
+  status
+  source
+  guildId
+  productCategoryId
+  buyer {
+    username
+  }
+  brandId
+}
+
 query findDemands(
   $productCategoryId: ID!
   $cursor: ID
@@ -35,7 +54,7 @@ query findDemands(
   ) {
     edges {
       node {
-        ...demand
+        ...demandPreview
       }
       cursor
     }

--- a/lib/graphql/guild.graphql
+++ b/lib/graphql/guild.graphql
@@ -27,6 +27,21 @@ fragment guild on GuildResponse {
   }
 }
 
+fragment guildPreview on GuildPreviewResponse {
+  id
+  name
+  slug
+  description
+  icon
+  position
+  offers {
+    ...offerPreview
+  }
+  demands {
+    ...demandPreview
+  }
+}
+
 query FindGuilds($cursor: ID, $skip: Int! = 1, $take: Int!) {
   findGuilds(cursor: $cursor, skip: $skip, take: $take) {
     edges {
@@ -43,5 +58,11 @@ query FindGuilds($cursor: ID, $skip: Int! = 1, $take: Int!) {
 query findGuild($slug: String!) {
   findGuild(slug: $slug) {
     ...guild
+  }
+}
+
+query findGuildPreviews {
+  findGuildPreviews {
+    ...guildPreview
   }
 }

--- a/lib/graphql/offer.graphql
+++ b/lib/graphql/offer.graphql
@@ -21,6 +21,28 @@ fragment offer on OfferResponse {
   brandId
 }
 
+fragment offerPreview on OfferResponse {
+  id
+  createdAt
+  updatedAt
+  name
+  slug
+  price
+  priceCurrency
+  businessFunction
+  status
+  source
+  thumbnail {
+    ...image
+  }
+  guildId
+  productCategoryId
+  seller {
+    username
+  }
+  brandId
+}
+
 query findOffers(
   $productCategoryId: ID!
   $cursor: ID
@@ -35,7 +57,7 @@ query findOffers(
   ) {
     edges {
       node {
-        ...offer
+        ...offerPreview
       }
       cursor
     }

--- a/lib/graphql/swap.graphql
+++ b/lib/graphql/swap.graphql
@@ -23,6 +23,29 @@ fragment swap on SwapResponse {
   brandId
 }
 
+fragment swapPreview on SwapResponse {
+  id
+  createdAt
+  updatedAt
+  slug
+  name0
+  name1
+  price
+  priceCurrency
+  businessFunction
+  status
+  source
+  thumbnail {
+    ...image
+  }
+  guildId
+  productCategoryId
+  proposer {
+    username
+  }
+  brandId
+}
+
 query findSwaps(
   $productCategoryId: ID!
   $cursor: ID
@@ -37,7 +60,7 @@ query findSwaps(
   ) {
     edges {
       node {
-        ...swap
+        ...swapPreview
       }
       cursor
     }


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
1. offer, demand, swap preview에서 모든 images를 가져오는 문제
2. home root에 길드 정보를 보여주는 페이지 만들기
3. guild, market, offer 경로로 바로 들어갈 때 나오는 not found 페이지

## 어떻게 해결했나요?
1. preview를 가져오는 query에는 전체 images 대신 thumbnail만 가져오기
2. findGuildPreview query를 통해, 길드 정보, 최신 판매, 구매글 3개씩을 가져와 길드 정보를 요약한 피드 생성
3. guild / market / offers, demands, swaps / default category 위치로 redirect 시키기