### PR TITLE
feat: update cache after mutation

### DIFF
--- a/components/deals/private-deal-menu.tsx
+++ b/components/deals/private-deal-menu.tsx
@@ -52,7 +52,6 @@ export default function PrivateDealMenu({
       dealType,
       updateDealInput,
     });
-    window.location.reload();
   };
 
   const handleEditClick: React.MouseEventHandler = (event) => {

--- a/components/demands/demand-detail.tsx
+++ b/components/demands/demand-detail.tsx
@@ -8,6 +8,7 @@ export default function DemandDetail({ slug }: { slug: string }) {
     variables: {
       slug: decodeURI(slug),
     },
+    fetchPolicy: 'network-only',
   });
 
   if (loading) return <div />;

--- a/components/demands/demand-feed.tsx
+++ b/components/demands/demand-feed.tsx
@@ -59,7 +59,9 @@ function DemandFeed({
   if (loading) return <Mocks length={12} height={32} color="bg-dark-400" />;
   if (!data?.findDemandPreviews) return <div />;
 
-  const { edges } = data.findDemandPreviews;
+  const edges = data.findDemandPreviews.edges.filter((edge) =>
+    status ? edge.node.status === status : true,
+  );
   return (
     <>
       {edges.map((edge) => (

--- a/components/demands/demand-report.tsx
+++ b/components/demands/demand-report.tsx
@@ -10,6 +10,7 @@ export default function DemandReport({ slug }: { slug: string }) {
     variables: {
       slug: decodeURI(slug),
     },
+    fetchPolicy: 'network-only',
   });
 
   if (loading) return <div />;

--- a/components/offers/offer-detail.tsx
+++ b/components/offers/offer-detail.tsx
@@ -8,6 +8,7 @@ export default function OfferDetail({ slug }: { slug: string }) {
     variables: {
       slug: decodeURI(slug),
     },
+    fetchPolicy: 'network-only',
   });
 
   if (loading) return <div />;

--- a/components/offers/offer-feed.tsx
+++ b/components/offers/offer-feed.tsx
@@ -59,7 +59,9 @@ function OfferFeed({
   if (loading) return <Mocks length={12} height={72} color="bg-dark-400" />;
   if (!data?.findOfferPreviews) return <div />;
 
-  const { edges } = data.findOfferPreviews;
+  const edges = data.findOfferPreviews.edges.filter((edge) =>
+    status ? edge.node.status === status : true,
+  );
   return (
     <>
       {edges.map((edge) => (

--- a/components/offers/offer-report.tsx
+++ b/components/offers/offer-report.tsx
@@ -10,6 +10,7 @@ export default function OfferReport({ slug }: { slug: string }) {
     variables: {
       slug: decodeURI(slug),
     },
+    fetchPolicy: 'network-only',
   });
 
   if (loading) return <div />;

--- a/components/swaps/swap-detail.tsx
+++ b/components/swaps/swap-detail.tsx
@@ -8,6 +8,7 @@ export default function SwapDetail({ slug }: { slug: string }) {
     variables: {
       slug: decodeURI(slug),
     },
+    fetchPolicy: 'network-only',
   });
 
   if (loading) return <div />;
@@ -28,5 +29,5 @@ export default function SwapDetail({ slug }: { slug: string }) {
       images={swap.images}
       reports={swap.reports}
     />
-  )
+  );
 }

--- a/components/swaps/swap-feed.tsx
+++ b/components/swaps/swap-feed.tsx
@@ -59,8 +59,9 @@ function SwapFeed({
   if (loading) return <Mocks length={12} height={72} color="bg-dark-400" />;
   if (!data?.findSwapPreviews) return <div />;
 
-  const { edges } = data.findSwapPreviews;
-
+  const edges = data.findSwapPreviews.edges.filter((edge) =>
+    status ? edge.node.status === status : true,
+  );
   return (
     <>
       {edges.map((edge) => (

--- a/components/swaps/swap-report.tsx
+++ b/components/swaps/swap-report.tsx
@@ -11,6 +11,7 @@ export default function SwapReport({ slug }: { slug: string }) {
     variables: {
       slug: decodeURI(slug),
     },
+    fetchPolicy: 'network-only',
   });
 
   if (loading) return <div />;

--- a/generated/graphql.ts
+++ b/generated/graphql.ts
@@ -1332,6 +1332,7 @@ export type UpdateSwapInput = {
   name1?: InputMaybe<Scalars['String']['input']>;
   price?: InputMaybe<Scalars['Int']['input']>;
   priceCurrency?: InputMaybe<Scalars['String']['input']>;
+  productCategoryId?: InputMaybe<Scalars['ID']['input']>;
   proposerId: Scalars['ID']['input'];
   source: Scalars['String']['input'];
   status?: InputMaybe<Scalars['String']['input']>;

--- a/generated/graphql.ts
+++ b/generated/graphql.ts
@@ -436,9 +436,9 @@ export type MemberWithRolesResponse = {
 export type Mutation = {
   __typename?: 'Mutation';
   addBid: Scalars['String']['output'];
-  bumpDemand: Scalars['String']['output'];
-  bumpOffer: Scalars['String']['output'];
-  bumpSwap: Scalars['String']['output'];
+  bumpDemand: DemandPreviewResponse;
+  bumpOffer: OfferPreviewResponse;
+  bumpSwap: SwapPreviewResponse;
   cancelBid: Scalars['String']['output'];
   commentDemandReport: Scalars['String']['output'];
   commentOfferReport: Scalars['String']['output'];
@@ -1463,7 +1463,7 @@ export type BumpDemandMutationVariables = Exact<{
 }>;
 
 
-export type BumpDemandMutation = { __typename?: 'Mutation', bumpDemand: string };
+export type BumpDemandMutation = { __typename?: 'Mutation', bumpDemand: { __typename?: 'DemandPreviewResponse', id: string, bumpedAt: any, price: number } };
 
 export type CommentDemandReportMutationVariables = Exact<{
   input: CommentDemandReportInput;
@@ -1554,7 +1554,7 @@ export type BumpOfferMutationVariables = Exact<{
 }>;
 
 
-export type BumpOfferMutation = { __typename?: 'Mutation', bumpOffer: string };
+export type BumpOfferMutation = { __typename?: 'Mutation', bumpOffer: { __typename?: 'OfferPreviewResponse', id: string, bumpedAt: any, price: number } };
 
 export type CommentOfferReportMutationVariables = Exact<{
   input: CommentOfferReportInput;
@@ -1680,7 +1680,7 @@ export type BumpSwapMutationVariables = Exact<{
 }>;
 
 
-export type BumpSwapMutation = { __typename?: 'Mutation', bumpSwap: string };
+export type BumpSwapMutation = { __typename?: 'Mutation', bumpSwap: { __typename?: 'SwapPreviewResponse', id: string, bumpedAt: any, price: number } };
 
 export type CommentSwapReportMutationVariables = Exact<{
   input: CommentSwapReportInput;
@@ -2529,7 +2529,11 @@ export type UpdateDemandMutationResult = Apollo.MutationResult<UpdateDemandMutat
 export type UpdateDemandMutationOptions = Apollo.BaseMutationOptions<UpdateDemandMutation, UpdateDemandMutationVariables>;
 export const BumpDemandDocument = gql`
     mutation BumpDemand($input: BumpDemandInput!) {
-  bumpDemand(input: $input)
+  bumpDemand(input: $input) {
+    id
+    bumpedAt
+    price
+  }
 }
     `;
 export type BumpDemandMutationFn = Apollo.MutationFunction<BumpDemandMutation, BumpDemandMutationVariables>;
@@ -2941,7 +2945,11 @@ export type UpdateOfferMutationResult = Apollo.MutationResult<UpdateOfferMutatio
 export type UpdateOfferMutationOptions = Apollo.BaseMutationOptions<UpdateOfferMutation, UpdateOfferMutationVariables>;
 export const BumpOfferDocument = gql`
     mutation BumpOffer($input: BumpOfferInput!) {
-  bumpOffer(input: $input)
+  bumpOffer(input: $input) {
+    id
+    bumpedAt
+    price
+  }
 }
     `;
 export type BumpOfferMutationFn = Apollo.MutationFunction<BumpOfferMutation, BumpOfferMutationVariables>;
@@ -3462,7 +3470,11 @@ export type UpdateSwapMutationResult = Apollo.MutationResult<UpdateSwapMutation>
 export type UpdateSwapMutationOptions = Apollo.BaseMutationOptions<UpdateSwapMutation, UpdateSwapMutationVariables>;
 export const BumpSwapDocument = gql`
     mutation BumpSwap($input: BumpSwapInput!) {
-  bumpSwap(input: $input)
+  bumpSwap(input: $input) {
+    id
+    bumpedAt
+    price
+  }
 }
     `;
 export type BumpSwapMutationFn = Apollo.MutationFunction<BumpSwapMutation, BumpSwapMutationVariables>;

--- a/generated/graphql.ts
+++ b/generated/graphql.ts
@@ -1456,7 +1456,7 @@ export type UpdateDemandMutationVariables = Exact<{
 }>;
 
 
-export type UpdateDemandMutation = { __typename?: 'Mutation', updateDemand: { __typename?: 'DemandPreviewResponse', id: string, status: string } };
+export type UpdateDemandMutation = { __typename?: 'Mutation', updateDemand: { __typename?: 'DemandPreviewResponse', id: string, status: string, name: string, price: number } };
 
 export type BumpDemandMutationVariables = Exact<{
   input: BumpDemandInput;
@@ -1547,7 +1547,7 @@ export type UpdateOfferMutationVariables = Exact<{
 }>;
 
 
-export type UpdateOfferMutation = { __typename?: 'Mutation', updateOffer: { __typename?: 'OfferPreviewResponse', id: string, status: string } };
+export type UpdateOfferMutation = { __typename?: 'Mutation', updateOffer: { __typename?: 'OfferPreviewResponse', id: string, status: string, name: string, price: number } };
 
 export type BumpOfferMutationVariables = Exact<{
   input: BumpOfferInput;
@@ -1673,7 +1673,7 @@ export type UpdateSwapMutationVariables = Exact<{
 }>;
 
 
-export type UpdateSwapMutation = { __typename?: 'Mutation', updateSwap: { __typename?: 'SwapPreviewResponse', id: string, status: string } };
+export type UpdateSwapMutation = { __typename?: 'Mutation', updateSwap: { __typename?: 'SwapPreviewResponse', id: string, status: string, name0: string, name1: string, price: number } };
 
 export type BumpSwapMutationVariables = Exact<{
   input: BumpSwapInput;
@@ -2498,6 +2498,8 @@ export const UpdateDemandDocument = gql`
   updateDemand(input: $input) {
     id
     status
+    name
+    price
   }
 }
     `;
@@ -2914,6 +2916,8 @@ export const UpdateOfferDocument = gql`
   updateOffer(input: $input) {
     id
     status
+    name
+    price
   }
 }
     `;
@@ -3439,6 +3443,9 @@ export const UpdateSwapDocument = gql`
   updateSwap(input: $input) {
     id
     status
+    name0
+    name1
+    price
   }
 }
     `;

--- a/generated/graphql.ts
+++ b/generated/graphql.ts
@@ -477,14 +477,14 @@ export type Mutation = {
   refreshTokens: JwtResponse;
   updateAuction: Scalars['String']['output'];
   updateComment: CommentResponse;
-  updateDemand: Scalars['String']['output'];
+  updateDemand: DemandPreviewResponse;
   updateGroup: Scalars['String']['output'];
   updateMember: Scalars['String']['output'];
-  updateOffer: Scalars['String']['output'];
+  updateOffer: OfferPreviewResponse;
   updateRole: Scalars['String']['output'];
   updateSession: Scalars['String']['output'];
   updateSocialAccount: Scalars['String']['output'];
-  updateSwap: Scalars['String']['output'];
+  updateSwap: SwapPreviewResponse;
   updateUser: Scalars['String']['output'];
   updateUserImage: Scalars['String']['output'];
 };
@@ -1456,7 +1456,7 @@ export type UpdateDemandMutationVariables = Exact<{
 }>;
 
 
-export type UpdateDemandMutation = { __typename?: 'Mutation', updateDemand: string };
+export type UpdateDemandMutation = { __typename?: 'Mutation', updateDemand: { __typename?: 'DemandPreviewResponse', id: string, status: string } };
 
 export type BumpDemandMutationVariables = Exact<{
   input: BumpDemandInput;
@@ -1547,7 +1547,7 @@ export type UpdateOfferMutationVariables = Exact<{
 }>;
 
 
-export type UpdateOfferMutation = { __typename?: 'Mutation', updateOffer: string };
+export type UpdateOfferMutation = { __typename?: 'Mutation', updateOffer: { __typename?: 'OfferPreviewResponse', id: string, status: string } };
 
 export type BumpOfferMutationVariables = Exact<{
   input: BumpOfferInput;
@@ -1673,7 +1673,7 @@ export type UpdateSwapMutationVariables = Exact<{
 }>;
 
 
-export type UpdateSwapMutation = { __typename?: 'Mutation', updateSwap: string };
+export type UpdateSwapMutation = { __typename?: 'Mutation', updateSwap: { __typename?: 'SwapPreviewResponse', id: string, status: string } };
 
 export type BumpSwapMutationVariables = Exact<{
   input: BumpSwapInput;
@@ -2495,7 +2495,10 @@ export type CreateDemandMutationResult = Apollo.MutationResult<CreateDemandMutat
 export type CreateDemandMutationOptions = Apollo.BaseMutationOptions<CreateDemandMutation, CreateDemandMutationVariables>;
 export const UpdateDemandDocument = gql`
     mutation UpdateDemand($input: UpdateDemandInput!) {
-  updateDemand(input: $input)
+  updateDemand(input: $input) {
+    id
+    status
+  }
 }
     `;
 export type UpdateDemandMutationFn = Apollo.MutationFunction<UpdateDemandMutation, UpdateDemandMutationVariables>;
@@ -2904,7 +2907,10 @@ export type CreateOfferMutationResult = Apollo.MutationResult<CreateOfferMutatio
 export type CreateOfferMutationOptions = Apollo.BaseMutationOptions<CreateOfferMutation, CreateOfferMutationVariables>;
 export const UpdateOfferDocument = gql`
     mutation UpdateOffer($input: UpdateOfferInput!) {
-  updateOffer(input: $input)
+  updateOffer(input: $input) {
+    id
+    status
+  }
 }
     `;
 export type UpdateOfferMutationFn = Apollo.MutationFunction<UpdateOfferMutation, UpdateOfferMutationVariables>;
@@ -3422,7 +3428,10 @@ export type CreateSwapMutationResult = Apollo.MutationResult<CreateSwapMutation>
 export type CreateSwapMutationOptions = Apollo.BaseMutationOptions<CreateSwapMutation, CreateSwapMutationVariables>;
 export const UpdateSwapDocument = gql`
     mutation UpdateSwap($input: UpdateSwapInput!) {
-  updateSwap(input: $input)
+  updateSwap(input: $input) {
+    id
+    status
+  }
 }
     `;
 export type UpdateSwapMutationFn = Apollo.MutationFunction<UpdateSwapMutation, UpdateSwapMutationVariables>;

--- a/lib/api/comment.ts
+++ b/lib/api/comment.ts
@@ -2,9 +2,6 @@ import {
   CreateCommentDocument,
   CreateCommentInput,
   CreateCommentMutation,
-  FindCommentDocument,
-  FindCommentQuery,
-  FindCommentQueryVariables,
   UpdateCommentDocument,
   UpdateCommentInput,
   UpdateCommentMutation,
@@ -25,30 +22,6 @@ export async function updateComment(input: UpdateCommentInput) {
     mutation: UpdateCommentDocument,
     variables: {
       input,
-    },
-    update: (cache, { data }) => {
-      if (!data?.updateComment) return;
-
-      const comment = data.updateComment;
-      let refId;
-      if (comment.type === 'post') {
-        refId = comment.postId;
-      } else if (comment.type === 'report') {
-        refId = comment.reportId;
-      } else if (comment.type === 'auction') {
-        refId = comment.auctionId;
-      } else {
-        return;
-      }
-
-      cache.writeQuery({
-        query: FindCommentDocument,
-        variables: {
-          type: data.updateComment.type,
-          refId,
-        },
-        data: data?.updateComment,
-      });
     },
   });
 }

--- a/lib/graphql/demand.graphql
+++ b/lib/graphql/demand.graphql
@@ -98,7 +98,10 @@ mutation CreateDemand($input: CreateDemandInput!) {
 }
 
 mutation UpdateDemand($input: UpdateDemandInput!) {
-  updateDemand(input: $input)
+  updateDemand(input: $input) {
+    id
+    status
+  }
 }
 
 mutation BumpDemand($input: BumpDemandInput!) {

--- a/lib/graphql/demand.graphql
+++ b/lib/graphql/demand.graphql
@@ -101,6 +101,8 @@ mutation UpdateDemand($input: UpdateDemandInput!) {
   updateDemand(input: $input) {
     id
     status
+    name
+    price
   }
 }
 

--- a/lib/graphql/demand.graphql
+++ b/lib/graphql/demand.graphql
@@ -105,7 +105,11 @@ mutation UpdateDemand($input: UpdateDemandInput!) {
 }
 
 mutation BumpDemand($input: BumpDemandInput!) {
-  bumpDemand(input: $input)
+  bumpDemand(input: $input) {
+    id
+    bumpedAt
+    price
+  }
 }
 
 mutation CommentDemandReport($input: CommentDemandReportInput!) {

--- a/lib/graphql/offer.graphql
+++ b/lib/graphql/offer.graphql
@@ -101,7 +101,10 @@ mutation CreateOffer($input: CreateOfferInput!) {
 }
 
 mutation UpdateOffer($input: UpdateOfferInput!) {
-  updateOffer(input: $input)
+  updateOffer(input: $input) {
+    id
+    status
+  }
 }
 
 mutation BumpOffer($input: BumpOfferInput!) {

--- a/lib/graphql/offer.graphql
+++ b/lib/graphql/offer.graphql
@@ -104,6 +104,8 @@ mutation UpdateOffer($input: UpdateOfferInput!) {
   updateOffer(input: $input) {
     id
     status
+    name
+    price
   }
 }
 

--- a/lib/graphql/offer.graphql
+++ b/lib/graphql/offer.graphql
@@ -108,7 +108,11 @@ mutation UpdateOffer($input: UpdateOfferInput!) {
 }
 
 mutation BumpOffer($input: BumpOfferInput!) {
-  bumpOffer(input: $input)
+  bumpOffer(input: $input) {
+    id
+    bumpedAt
+    price
+  }
 }
 
 mutation CommentOfferReport($input: CommentOfferReportInput!) {

--- a/lib/graphql/swap.graphql
+++ b/lib/graphql/swap.graphql
@@ -111,7 +111,11 @@ mutation UpdateSwap($input: UpdateSwapInput!) {
 }
 
 mutation BumpSwap($input: BumpSwapInput!) {
-  bumpSwap(input: $input)
+  bumpSwap(input: $input) {
+    id
+    bumpedAt
+    price
+  }
 }
 
 mutation CommentSwapReport($input: CommentSwapReportInput!) {

--- a/lib/graphql/swap.graphql
+++ b/lib/graphql/swap.graphql
@@ -107,6 +107,9 @@ mutation UpdateSwap($input: UpdateSwapInput!) {
   updateSwap(input: $input) {
     id
     status
+    name0
+    name1
+    price
   }
 }
 

--- a/lib/graphql/swap.graphql
+++ b/lib/graphql/swap.graphql
@@ -104,7 +104,10 @@ mutation CreateSwap($input: CreateSwapInput!) {
 }
 
 mutation UpdateSwap($input: UpdateSwapInput!) {
-  updateSwap(input: $input)
+  updateSwap(input: $input) {
+    id
+    status
+  }
 }
 
 mutation BumpSwap($input: BumpSwapInput!) {


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
게시글 수정, 끌올 후에 캐시 값 업데이트하기

## 어떻게 해결했나요?
1. detail page의 fetchPolicy를 network-only로 설정
2. mutation의 response 를 previewResponse로 설정
