### PR TITLE
feat: subscribe reactionCreated, reactionCanceled in Comment Output

### DIFF
--- a/components/comments/comment-card.tsx
+++ b/components/comments/comment-card.tsx
@@ -16,6 +16,7 @@ import Avatar from '../avatar/avatar';
 export default function CommentCard({
   user,
   isCurrentUser,
+  postId,
   displayMenu,
   defaultMode,
   commentId,
@@ -29,6 +30,7 @@ export default function CommentCard({
 }: {
   user?: AuthorResponse;
   isCurrentUser: boolean;
+  postId?: string;
   displayMenu: boolean;
   defaultMode: CRUD;
   commentId?: string;
@@ -125,11 +127,12 @@ export default function CommentCard({
     );
   }
 
-  if (!user || !commentId) return <div />;
+  if (!user || !postId || !commentId) return <div />;
   return (
     <CommentOutput
       user={user}
       isCurrentUser={isCurrentUser}
+      postId={postId}
       content={content}
       createdAt={createdAt}
       updatedAt={updatedAt}

--- a/components/comments/comment-feed.tsx
+++ b/components/comments/comment-feed.tsx
@@ -158,6 +158,7 @@ export default function CommentFeed({
             key={comment.id}
             user={comment.user}
             isCurrentUser={jwtPayload?.id === comment.user.id}
+            postId={comment.postId}
             displayMenu
             defaultMode="read"
             commentId={comment.id}

--- a/components/comments/comment-feed.tsx
+++ b/components/comments/comment-feed.tsx
@@ -14,6 +14,7 @@ import {
   useFindAuthorQuery,
 } from '@/generated/graphql';
 import { useSubscription } from '@apollo/client';
+import { scrollToBottom } from '@/lib/scroll/scroll-to-bottom';
 import CommentCard from './comment-card';
 import { AuthContext } from '../auth/auth.provider';
 import DeleteConfirmationDialog from '../base/delete-confirmation-dialog';
@@ -33,36 +34,61 @@ export default function CommentFeed({
   );
   const [comments, setComments] = useState<CommentWithAuthorResponse[]>([]); // State to store comments
   const [isAtBottom, setIsAtBottom] = useState(false);
-  const commentsContainerRef = useRef<HTMLDivElement>(null);
+  const buffer = 50;
 
-  // Scroll to bottom function
-  const scrollToBottom = () => {
-    const container = commentsContainerRef.current;
+  // Event handler for scrolling
+  const handleScroll = () => {
+    const scrollTop = window.scrollY || document.documentElement.scrollTop;
+    const { scrollHeight } = document.documentElement;
+    const { clientHeight } = document.documentElement;
+    setIsAtBottom(scrollTop + clientHeight >= scrollHeight - buffer);
+  };
 
-    if (container) {
-      container.scrollTop = container.scrollHeight;
-    }
+  const handleWrite = async (values: CommentValues) => {
+    if (!jwtPayload || !where.postId || !values.content) return;
+
+    await createComment({
+      id: values.id,
+      content: values.content,
+      postId: where.postId,
+    });
+    scrollToBottom();
+  };
+
+  const handleEdit = async (values: CommentValues) => {
+    if (!values.content) return;
+
+    await updateComment({
+      id: values.id,
+      content: values.content,
+    });
+  };
+
+  const handleDeleteConfirmation = (comment: CommentValues) => {
+    setCommentToDelete(comment);
+    setDeleteDialogOpen(true);
+  };
+
+  const handleCloseDeleteDialog = () => {
+    setCommentToDelete(null);
+    setDeleteDialogOpen(false);
+  };
+
+  const handleDelete = async (values: CommentValues) => {
+    if (!values.id) return;
+
+    await deleteComment({
+      id: values.id,
+    });
+    handleCloseDeleteDialog();
   };
 
   useEffect(() => {
-    const handleScroll = () => {
-      const container = commentsContainerRef.current;
-      if (container) {
-        const newIsAtBottom =
-          container.scrollHeight - container.clientHeight <=
-          container.scrollTop + 1;
-        setIsAtBottom(newIsAtBottom);
-      }
-    };
+    window.addEventListener('scroll', handleScroll);
 
-    const container = commentsContainerRef.current;
-    if (container) {
-      container.addEventListener('scroll', handleScroll);
-      return () => {
-        container.removeEventListener('scroll', handleScroll);
-      };
-    }
-    return () => {};
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
   }, []);
 
   useEffect(() => {
@@ -104,55 +130,13 @@ export default function CommentFeed({
   }, [commentsLoading, commentsData]);
 
   if (commentsLoading || userLoading) return <div />;
-  if (!commentsData?.findComments) return <div />;
+  if (!comments.length) return <div />;
 
   const user = UserData?.findAuthor;
 
-  const handleWrite = async (values: CommentValues) => {
-    if (!jwtPayload || !where.postId || !values.content) return;
-
-    await createComment({
-      id: values.id,
-      content: values.content,
-      postId: where.postId,
-    });
-    scrollToBottom();
-  };
-
-  const handleEdit = async (values: CommentValues) => {
-    if (!values.content) return;
-
-    await updateComment({
-      id: values.id,
-      content: values.content,
-    });
-  };
-
-  const handleDeleteConfirmation = (comment: CommentValues) => {
-    setCommentToDelete(comment);
-    setDeleteDialogOpen(true);
-  };
-
-  const handleCloseDeleteDialog = () => {
-    setCommentToDelete(null);
-    setDeleteDialogOpen(false);
-  };
-
-  const handleDelete = async (values: CommentValues) => {
-    if (!values.id) return;
-
-    await deleteComment({
-      id: values.id,
-    });
-    handleCloseDeleteDialog();
-  };
-
   return (
-    <div className="flex flex-col relative pb-0 lg:pb-32">
-      <div
-        className="flex-1 flex flex-col gap-6 overflow-x-hidden"
-        ref={commentsContainerRef}
-      >
+    <div className="flex flex-col relative pb-16 lg:pb-32">
+      <div className="flex-1 flex flex-col gap-6">
         {comments.map((comment) => (
           <CommentCard
             key={comment.id}

--- a/components/comments/comment-feed.tsx
+++ b/components/comments/comment-feed.tsx
@@ -73,8 +73,11 @@ export default function CommentFeed({
   }, [comments]);
 
   useSubscription(CommentCreatedDocument, {
-    onSubscriptionData: ({ subscriptionData }) => {
-      const newComment = subscriptionData.data.commentCreated;
+    variables: {
+      postId: where.postId,
+    },
+    onData: ({ data }) => {
+      const newComment = data.data.commentCreated;
       setComments([...comments, newComment]);
     },
     shouldResubscribe: true, // Always resubscribe
@@ -147,7 +150,7 @@ export default function CommentFeed({
   return (
     <div className="flex flex-col relative pb-0 lg:pb-32">
       <div
-        className="flex-1 flex flex-col gap-6 overflow-x-hidden overflow-y-auto max-h-[60vh] lg:max-h-[75vh]"
+        className="flex-1 flex flex-col gap-6 overflow-x-hidden"
         ref={commentsContainerRef}
       >
         {comments.map((comment) => (

--- a/components/reaction/reaction-bar.tsx
+++ b/components/reaction/reaction-bar.tsx
@@ -12,7 +12,7 @@ export default function ReactionBar({
   commentId,
   reactions,
 }: {
-  postId?: string | null;
+  postId: string;
   commentId?: string | null;
   reactions: ReactionResponse[];
 }) {

--- a/components/user-review/user-review-detail-main.tsx
+++ b/components/user-review/user-review-detail-main.tsx
@@ -4,6 +4,7 @@ import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useDeviceDetect } from '@/hooks/use-device-detect';
 import {
+  ReactionCanceledDocument,
   ReactionCreatedDocument,
   ReactionResponse,
   UserReviewResponse,
@@ -29,6 +30,16 @@ export default function UserReviewDetailMain({
     onData: ({ data }) => {
       const newReaction = data.data.reactionCreated;
       setPostReactions((prevReactions) => [...prevReactions, newReaction]);
+    },
+    shouldResubscribe: true,
+  });
+
+  useSubscription(ReactionCanceledDocument, {
+    onData: ({ data }) => {
+      const canceledReaction = data.data.reactionCanceled;
+      setPostReactions((prevReactions) =>
+        prevReactions.filter((reaction) => reaction.id !== canceledReaction.id),
+      );
     },
     shouldResubscribe: true,
   });

--- a/components/user-review/user-review-detail-main.tsx
+++ b/components/user-review/user-review-detail-main.tsx
@@ -47,7 +47,7 @@ export default function UserReviewDetailMain({
 
   useSubscription(ReactionCanceledDocument, {
     variables: {
-      postid: userReview.post.id,
+      postId: userReview.post.id,
     },
     onData: ({ data }) => {
       const canceledReaction = data.data.reactionCanceled;

--- a/components/user-review/user-review-detail-main.tsx
+++ b/components/user-review/user-review-detail-main.tsx
@@ -36,6 +36,7 @@ export default function UserReviewDetailMain({
 
   useSubscription(ReactionCreatedDocument, {
     variables: {
+      type: 'post',
       postId: userReview.post.id,
     },
     onData: ({ data }) => {
@@ -47,6 +48,7 @@ export default function UserReviewDetailMain({
 
   useSubscription(ReactionCanceledDocument, {
     variables: {
+      type: 'post',
       postId: userReview.post.id,
     },
     onData: ({ data }) => {

--- a/components/user-review/user-review-detail-main.tsx
+++ b/components/user-review/user-review-detail-main.tsx
@@ -8,6 +8,7 @@ import {
   ReactionCreatedDocument,
   ReactionResponse,
   UserReviewResponse,
+  useFindReactionsQuery,
 } from '@/generated/graphql';
 import ArrowRightAltIcon from '@mui/icons-material/ArrowRightAlt';
 import { useSubscription } from '@apollo/client';
@@ -26,7 +27,17 @@ export default function UserReviewDetailMain({
   const device = useDeviceDetect();
   const [postReactions, setPostReactions] = useState<ReactionResponse[]>([]);
 
+  const { loading, data: postReactionsData } = useFindReactionsQuery({
+    variables: {
+      postId: userReview.post.id,
+    },
+    fetchPolicy: 'cache-and-network',
+  });
+
   useSubscription(ReactionCreatedDocument, {
+    variables: {
+      postId: userReview.post.id,
+    },
     onData: ({ data }) => {
       const newReaction = data.data.reactionCreated;
       setPostReactions((prevReactions) => [...prevReactions, newReaction]);
@@ -35,6 +46,9 @@ export default function UserReviewDetailMain({
   });
 
   useSubscription(ReactionCanceledDocument, {
+    variables: {
+      postid: userReview.post.id,
+    },
     onData: ({ data }) => {
       const canceledReaction = data.data.reactionCanceled;
       setPostReactions((prevReactions) =>
@@ -45,8 +59,10 @@ export default function UserReviewDetailMain({
   });
 
   useEffect(() => {
-    setPostReactions(userReview.post.reactions);
-  }, [userReview.post.reactions]);
+    if (!loading && postReactionsData) {
+      setPostReactions(postReactionsData.findReactions);
+    }
+  }, [loading, postReactionsData]);
 
   return (
     <>

--- a/generated/graphql.ts
+++ b/generated/graphql.ts
@@ -43,6 +43,11 @@ export type CancelReactionInput = {
   postId?: InputMaybe<Scalars['ID']['input']>;
 };
 
+export type CanceledReactionResponse = {
+  __typename?: 'CanceledReactionResponse';
+  id: Scalars['ID']['output'];
+};
+
 export type CategoryResponse = {
   __typename?: 'CategoryResponse';
   description?: Maybe<Scalars['String']['output']>;
@@ -937,6 +942,8 @@ export type SocialUserResponse = {
 export type Subscription = {
   __typename?: 'Subscription';
   commentCreated: CommentWithAuthorResponse;
+  reactionCanceled: CanceledReactionResponse;
+  reactionCreated: ReactionResponse;
 };
 
 export type TagResponse = {
@@ -1314,6 +1321,11 @@ export type CancelReactionMutationVariables = Exact<{
 
 
 export type CancelReactionMutation = { __typename?: 'Mutation', cancelReaction: string };
+
+export type ReactionCreatedSubscriptionVariables = Exact<{ [key: string]: never; }>;
+
+
+export type ReactionCreatedSubscription = { __typename?: 'Subscription', reactionCreated: { __typename?: 'ReactionResponse', id: string, createdAt: any, updatedAt: any, canceledAt?: any | null, userId: string, postId?: string | null, commentId?: string | null, emoji: { __typename?: 'EmojiResponse', id: string, name: string, url?: string | null, position: number, groupId?: string | null } } };
 
 export type LastReportFragment = { __typename?: 'LastReportResponse', id: string, createdAt: any };
 
@@ -2957,6 +2969,35 @@ export function useCancelReactionMutation(baseOptions?: Apollo.MutationHookOptio
 export type CancelReactionMutationHookResult = ReturnType<typeof useCancelReactionMutation>;
 export type CancelReactionMutationResult = Apollo.MutationResult<CancelReactionMutation>;
 export type CancelReactionMutationOptions = Apollo.BaseMutationOptions<CancelReactionMutation, CancelReactionMutationVariables>;
+export const ReactionCreatedDocument = gql`
+    subscription ReactionCreated {
+  reactionCreated {
+    ...reaction
+  }
+}
+    ${ReactionFragmentDoc}`;
+
+/**
+ * __useReactionCreatedSubscription__
+ *
+ * To run a query within a React component, call `useReactionCreatedSubscription` and pass it any options that fit your needs.
+ * When your component renders, `useReactionCreatedSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useReactionCreatedSubscription({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useReactionCreatedSubscription(baseOptions?: Apollo.SubscriptionHookOptions<ReactionCreatedSubscription, ReactionCreatedSubscriptionVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useSubscription<ReactionCreatedSubscription, ReactionCreatedSubscriptionVariables>(ReactionCreatedDocument, options);
+      }
+export type ReactionCreatedSubscriptionHookResult = ReturnType<typeof useReactionCreatedSubscription>;
+export type ReactionCreatedSubscriptionResult = Apollo.SubscriptionResult<ReactionCreatedSubscription>;
 export const CreateReportDocument = gql`
     mutation CreateReport($input: CreateReportInput!) {
   createReport(input: $input)

--- a/generated/graphql.ts
+++ b/generated/graphql.ts
@@ -1327,6 +1327,11 @@ export type ReactionCreatedSubscriptionVariables = Exact<{ [key: string]: never;
 
 export type ReactionCreatedSubscription = { __typename?: 'Subscription', reactionCreated: { __typename?: 'ReactionResponse', id: string, createdAt: any, updatedAt: any, canceledAt?: any | null, userId: string, postId?: string | null, commentId?: string | null, emoji: { __typename?: 'EmojiResponse', id: string, name: string, url?: string | null, position: number, groupId?: string | null } } };
 
+export type ReactionCanceledSubscriptionVariables = Exact<{ [key: string]: never; }>;
+
+
+export type ReactionCanceledSubscription = { __typename?: 'Subscription', reactionCanceled: { __typename?: 'CanceledReactionResponse', id: string } };
+
 export type LastReportFragment = { __typename?: 'LastReportResponse', id: string, createdAt: any };
 
 export type ReportPreviewFragment = { __typename?: 'ReportPreviewResponse', id: string, createdAt: any, updatedAt: any, type: string, reportedPostId?: string | null, reportedCommentId?: string | null, groupId: string, status: string, reason: string, description?: string | null, reportedUser: { __typename?: 'AuthorResponse', id: string, createdAt: any, username: string, about?: string | null, avatarURL?: string | null, bot: boolean, socialAccounts: Array<{ __typename?: 'SocialAccountWithoutAuthResponse', id: string, createdAt: any, provider: string, socialId: string, userId: string }>, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, groupId: string }> } };
@@ -2998,6 +3003,35 @@ export function useReactionCreatedSubscription(baseOptions?: Apollo.Subscription
       }
 export type ReactionCreatedSubscriptionHookResult = ReturnType<typeof useReactionCreatedSubscription>;
 export type ReactionCreatedSubscriptionResult = Apollo.SubscriptionResult<ReactionCreatedSubscription>;
+export const ReactionCanceledDocument = gql`
+    subscription ReactionCanceled {
+  reactionCanceled {
+    id
+  }
+}
+    `;
+
+/**
+ * __useReactionCanceledSubscription__
+ *
+ * To run a query within a React component, call `useReactionCanceledSubscription` and pass it any options that fit your needs.
+ * When your component renders, `useReactionCanceledSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useReactionCanceledSubscription({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useReactionCanceledSubscription(baseOptions?: Apollo.SubscriptionHookOptions<ReactionCanceledSubscription, ReactionCanceledSubscriptionVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useSubscription<ReactionCanceledSubscription, ReactionCanceledSubscriptionVariables>(ReactionCanceledDocument, options);
+      }
+export type ReactionCanceledSubscriptionHookResult = ReturnType<typeof useReactionCanceledSubscription>;
+export type ReactionCanceledSubscriptionResult = Apollo.SubscriptionResult<ReactionCanceledSubscription>;
 export const CreateReportDocument = gql`
     mutation CreateReport($input: CreateReportInput!) {
   createReport(input: $input)

--- a/generated/graphql.ts
+++ b/generated/graphql.ts
@@ -615,29 +615,6 @@ export type PostResponse = {
   user: AuthorResponse;
 };
 
-export type PostWithReactionsResponse = {
-  __typename?: 'PostWithReactionsResponse';
-  archivedAt?: Maybe<Scalars['DateTime']['output']>;
-  category?: Maybe<CategoryResponse>;
-  categoryId?: Maybe<Scalars['String']['output']>;
-  createdAt: Scalars['DateTime']['output'];
-  group: GroupProfileResponse;
-  groupId: Scalars['String']['output'];
-  id: Scalars['ID']['output'];
-  images: Array<UserImageResponse>;
-  pending?: Maybe<Scalars['String']['output']>;
-  reactions: Array<ReactionResponse>;
-  reportCommentCount: Scalars['Int']['output'];
-  reportCount: Scalars['Int']['output'];
-  slug?: Maybe<Scalars['String']['output']>;
-  tags: Array<TagResponse>;
-  thumbnail?: Maybe<Scalars['String']['output']>;
-  title: Scalars['String']['output'];
-  type: Scalars['String']['output'];
-  updatedAt: Scalars['DateTime']['output'];
-  user: AuthorResponse;
-};
-
 export type Query = {
   __typename?: 'Query';
   findAuthor?: Maybe<AuthorResponse>;
@@ -1090,7 +1067,7 @@ export type UserReviewResponse = {
   createdAt: Scalars['DateTime']['output'];
   id: Scalars['ID']['output'];
   offerId?: Maybe<Scalars['String']['output']>;
-  post: PostWithReactionsResponse;
+  post: PostResponse;
   rating: Scalars['Int']['output'];
   reviewedUser: AuthorResponse;
   status: Scalars['String']['output'];
@@ -1291,8 +1268,6 @@ export type BumpOfferMutation = { __typename?: 'Mutation', bumpOffer: { __typena
 
 export type PostFragment = { __typename?: 'PostResponse', id: string, createdAt: any, updatedAt: any, archivedAt?: any | null, pending?: string | null, type: string, title: string, slug?: string | null, thumbnail?: string | null, reportCount: number, reportCommentCount: number, groupId: string, categoryId?: string | null, images: Array<{ __typename?: 'UserImageResponse', id: string, createdAt: any, updatedAt: any, name: string, url: string, contentType?: string | null, description?: string | null, size?: number | null, height?: number | null, width?: number | null, position: number, type: string, refId: string, userId: string }>, group: { __typename?: 'GroupProfileResponse', id: string, name: string, slug?: string | null, description?: string | null, icon?: string | null }, category?: { __typename?: 'CategoryResponse', id: string, type: string, name: string, slug?: string | null, position?: number | null } | null, user: { __typename?: 'AuthorResponse', id: string, createdAt: any, username: string, about?: string | null, avatarURL?: string | null, bot: boolean, socialAccounts: Array<{ __typename?: 'SocialAccountWithoutAuthResponse', id: string, createdAt: any, provider: string, socialId: string, userId: string }>, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, groupId: string }> }, tags: Array<{ __typename?: 'TagResponse', id: string, type: string, name: string, description?: string | null, position: number }> };
 
-export type PostWithReactionsFragment = { __typename?: 'PostWithReactionsResponse', id: string, createdAt: any, updatedAt: any, archivedAt?: any | null, pending?: string | null, type: string, title: string, slug?: string | null, thumbnail?: string | null, reportCount: number, reportCommentCount: number, groupId: string, categoryId?: string | null, images: Array<{ __typename?: 'UserImageResponse', id: string, createdAt: any, updatedAt: any, name: string, url: string, contentType?: string | null, description?: string | null, size?: number | null, height?: number | null, width?: number | null, position: number, type: string, refId: string, userId: string }>, group: { __typename?: 'GroupProfileResponse', id: string, name: string, slug?: string | null, description?: string | null, icon?: string | null }, category?: { __typename?: 'CategoryResponse', id: string, type: string, name: string, slug?: string | null, position?: number | null } | null, user: { __typename?: 'AuthorResponse', id: string, createdAt: any, username: string, about?: string | null, avatarURL?: string | null, bot: boolean, socialAccounts: Array<{ __typename?: 'SocialAccountWithoutAuthResponse', id: string, createdAt: any, provider: string, socialId: string, userId: string }>, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, groupId: string }> }, tags: Array<{ __typename?: 'TagResponse', id: string, type: string, name: string, description?: string | null, position: number }>, reactions: Array<{ __typename?: 'ReactionResponse', id: string, createdAt: any, updatedAt: any, canceledAt?: any | null, userId: string, postId?: string | null, commentId?: string | null, emoji: { __typename?: 'EmojiResponse', id: string, name: string, url?: string | null, position: number, groupId?: string | null } }> };
-
 export type PostPreviewWithoutUserFragment = { __typename?: 'PostPreviewWithoutUserResponse', id: string, createdAt: any, updatedAt: any, archivedAt?: any | null, pending?: string | null, type: string, title: string, slug?: string | null, thumbnail?: string | null, groupId: string, categoryId?: string | null, reportCount: number, reportCommentCount: number, tags: Array<{ __typename?: 'TagResponse', id: string, type: string, name: string, description?: string | null, position: number }> };
 
 export type PostPreviewWithUserFragment = { __typename?: 'PostPreviewWithUserResponse', id: string, createdAt: any, updatedAt: any, archivedAt?: any | null, pending?: string | null, type: string, title: string, slug?: string | null, thumbnail?: string | null, groupId: string, categoryId?: string | null, reportCount: number, reportCommentCount: number, user: { __typename?: 'UserResponse', id: string, createdAt: any, username: string, about?: string | null, avatarURL?: string | null, bot: boolean }, tags: Array<{ __typename?: 'TagResponse', id: string, type: string, name: string, description?: string | null, position: number }> };
@@ -1437,7 +1412,7 @@ export type DeleteUserImageMutation = { __typename?: 'Mutation', deleteUserImage
 
 export type UserReviewPreviewFragment = { __typename?: 'UserReviewPreviewResponse', id: string, createdAt: any, updatedAt: any, type: string, offerId?: string | null, auctionId?: string | null, content?: string | null, rating: number, status: string, post: { __typename?: 'PostPreviewWithAuthorResponse', id: string, createdAt: any, updatedAt: any, archivedAt?: any | null, pending?: string | null, type: string, title: string, slug?: string | null, thumbnail?: string | null, groupId: string, categoryId?: string | null, reportCount: number, reportCommentCount: number, user: { __typename?: 'AuthorResponse', id: string, createdAt: any, username: string, about?: string | null, avatarURL?: string | null, bot: boolean, socialAccounts: Array<{ __typename?: 'SocialAccountWithoutAuthResponse', id: string, createdAt: any, provider: string, socialId: string, userId: string }>, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, groupId: string }> }, tags: Array<{ __typename?: 'TagResponse', id: string, type: string, name: string, description?: string | null, position: number }> }, reviewedUser: { __typename?: 'AuthorResponse', id: string, createdAt: any, username: string, about?: string | null, avatarURL?: string | null, bot: boolean, socialAccounts: Array<{ __typename?: 'SocialAccountWithoutAuthResponse', id: string, createdAt: any, provider: string, socialId: string, userId: string }>, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, groupId: string }> } };
 
-export type UserReviewFragment = { __typename?: 'UserReviewResponse', id: string, createdAt: any, updatedAt: any, type: string, offerId?: string | null, auctionId?: string | null, content?: string | null, rating: number, status: string, post: { __typename?: 'PostWithReactionsResponse', id: string, createdAt: any, updatedAt: any, archivedAt?: any | null, pending?: string | null, type: string, title: string, slug?: string | null, thumbnail?: string | null, reportCount: number, reportCommentCount: number, groupId: string, categoryId?: string | null, images: Array<{ __typename?: 'UserImageResponse', id: string, createdAt: any, updatedAt: any, name: string, url: string, contentType?: string | null, description?: string | null, size?: number | null, height?: number | null, width?: number | null, position: number, type: string, refId: string, userId: string }>, group: { __typename?: 'GroupProfileResponse', id: string, name: string, slug?: string | null, description?: string | null, icon?: string | null }, category?: { __typename?: 'CategoryResponse', id: string, type: string, name: string, slug?: string | null, position?: number | null } | null, user: { __typename?: 'AuthorResponse', id: string, createdAt: any, username: string, about?: string | null, avatarURL?: string | null, bot: boolean, socialAccounts: Array<{ __typename?: 'SocialAccountWithoutAuthResponse', id: string, createdAt: any, provider: string, socialId: string, userId: string }>, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, groupId: string }> }, tags: Array<{ __typename?: 'TagResponse', id: string, type: string, name: string, description?: string | null, position: number }>, reactions: Array<{ __typename?: 'ReactionResponse', id: string, createdAt: any, updatedAt: any, canceledAt?: any | null, userId: string, postId?: string | null, commentId?: string | null, emoji: { __typename?: 'EmojiResponse', id: string, name: string, url?: string | null, position: number, groupId?: string | null } }> }, reviewedUser: { __typename?: 'AuthorResponse', id: string, createdAt: any, username: string, about?: string | null, avatarURL?: string | null, bot: boolean, socialAccounts: Array<{ __typename?: 'SocialAccountWithoutAuthResponse', id: string, createdAt: any, provider: string, socialId: string, userId: string }>, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, groupId: string }> } };
+export type UserReviewFragment = { __typename?: 'UserReviewResponse', id: string, createdAt: any, updatedAt: any, type: string, offerId?: string | null, auctionId?: string | null, content?: string | null, rating: number, status: string, post: { __typename?: 'PostResponse', id: string, createdAt: any, updatedAt: any, archivedAt?: any | null, pending?: string | null, type: string, title: string, slug?: string | null, thumbnail?: string | null, reportCount: number, reportCommentCount: number, groupId: string, categoryId?: string | null, images: Array<{ __typename?: 'UserImageResponse', id: string, createdAt: any, updatedAt: any, name: string, url: string, contentType?: string | null, description?: string | null, size?: number | null, height?: number | null, width?: number | null, position: number, type: string, refId: string, userId: string }>, group: { __typename?: 'GroupProfileResponse', id: string, name: string, slug?: string | null, description?: string | null, icon?: string | null }, category?: { __typename?: 'CategoryResponse', id: string, type: string, name: string, slug?: string | null, position?: number | null } | null, user: { __typename?: 'AuthorResponse', id: string, createdAt: any, username: string, about?: string | null, avatarURL?: string | null, bot: boolean, socialAccounts: Array<{ __typename?: 'SocialAccountWithoutAuthResponse', id: string, createdAt: any, provider: string, socialId: string, userId: string }>, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, groupId: string }> }, tags: Array<{ __typename?: 'TagResponse', id: string, type: string, name: string, description?: string | null, position: number }> }, reviewedUser: { __typename?: 'AuthorResponse', id: string, createdAt: any, username: string, about?: string | null, avatarURL?: string | null, bot: boolean, socialAccounts: Array<{ __typename?: 'SocialAccountWithoutAuthResponse', id: string, createdAt: any, provider: string, socialId: string, userId: string }>, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, groupId: string }> } };
 
 export type FindUserReviewPreviewsQueryVariables = Exact<{
   where?: InputMaybe<Scalars['JSON']['input']>;
@@ -1457,7 +1432,7 @@ export type FindUserReviewQueryVariables = Exact<{
 }>;
 
 
-export type FindUserReviewQuery = { __typename?: 'Query', findUserReview?: { __typename?: 'UserReviewResponse', id: string, createdAt: any, updatedAt: any, type: string, offerId?: string | null, auctionId?: string | null, content?: string | null, rating: number, status: string, post: { __typename?: 'PostWithReactionsResponse', id: string, createdAt: any, updatedAt: any, archivedAt?: any | null, pending?: string | null, type: string, title: string, slug?: string | null, thumbnail?: string | null, reportCount: number, reportCommentCount: number, groupId: string, categoryId?: string | null, images: Array<{ __typename?: 'UserImageResponse', id: string, createdAt: any, updatedAt: any, name: string, url: string, contentType?: string | null, description?: string | null, size?: number | null, height?: number | null, width?: number | null, position: number, type: string, refId: string, userId: string }>, group: { __typename?: 'GroupProfileResponse', id: string, name: string, slug?: string | null, description?: string | null, icon?: string | null }, category?: { __typename?: 'CategoryResponse', id: string, type: string, name: string, slug?: string | null, position?: number | null } | null, user: { __typename?: 'AuthorResponse', id: string, createdAt: any, username: string, about?: string | null, avatarURL?: string | null, bot: boolean, socialAccounts: Array<{ __typename?: 'SocialAccountWithoutAuthResponse', id: string, createdAt: any, provider: string, socialId: string, userId: string }>, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, groupId: string }> }, tags: Array<{ __typename?: 'TagResponse', id: string, type: string, name: string, description?: string | null, position: number }>, reactions: Array<{ __typename?: 'ReactionResponse', id: string, createdAt: any, updatedAt: any, canceledAt?: any | null, userId: string, postId?: string | null, commentId?: string | null, emoji: { __typename?: 'EmojiResponse', id: string, name: string, url?: string | null, position: number, groupId?: string | null } }> }, reviewedUser: { __typename?: 'AuthorResponse', id: string, createdAt: any, username: string, about?: string | null, avatarURL?: string | null, bot: boolean, socialAccounts: Array<{ __typename?: 'SocialAccountWithoutAuthResponse', id: string, createdAt: any, provider: string, socialId: string, userId: string }>, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, groupId: string }> } } | null };
+export type FindUserReviewQuery = { __typename?: 'Query', findUserReview?: { __typename?: 'UserReviewResponse', id: string, createdAt: any, updatedAt: any, type: string, offerId?: string | null, auctionId?: string | null, content?: string | null, rating: number, status: string, post: { __typename?: 'PostResponse', id: string, createdAt: any, updatedAt: any, archivedAt?: any | null, pending?: string | null, type: string, title: string, slug?: string | null, thumbnail?: string | null, reportCount: number, reportCommentCount: number, groupId: string, categoryId?: string | null, images: Array<{ __typename?: 'UserImageResponse', id: string, createdAt: any, updatedAt: any, name: string, url: string, contentType?: string | null, description?: string | null, size?: number | null, height?: number | null, width?: number | null, position: number, type: string, refId: string, userId: string }>, group: { __typename?: 'GroupProfileResponse', id: string, name: string, slug?: string | null, description?: string | null, icon?: string | null }, category?: { __typename?: 'CategoryResponse', id: string, type: string, name: string, slug?: string | null, position?: number | null } | null, user: { __typename?: 'AuthorResponse', id: string, createdAt: any, username: string, about?: string | null, avatarURL?: string | null, bot: boolean, socialAccounts: Array<{ __typename?: 'SocialAccountWithoutAuthResponse', id: string, createdAt: any, provider: string, socialId: string, userId: string }>, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, groupId: string }> }, tags: Array<{ __typename?: 'TagResponse', id: string, type: string, name: string, description?: string | null, position: number }> }, reviewedUser: { __typename?: 'AuthorResponse', id: string, createdAt: any, username: string, about?: string | null, avatarURL?: string | null, bot: boolean, socialAccounts: Array<{ __typename?: 'SocialAccountWithoutAuthResponse', id: string, createdAt: any, provider: string, socialId: string, userId: string }>, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, groupId: string }> } } | null };
 
 export type CreateUserReviewMutationVariables = Exact<{
   input: CreateUserReviewInput;
@@ -1799,6 +1774,29 @@ export const OfferFragmentDoc = gql`
   status
 }
     ${PostFragmentDoc}`;
+export const EmojiFragmentDoc = gql`
+    fragment emoji on EmojiResponse {
+  id
+  name
+  url
+  position
+  groupId
+}
+    `;
+export const ReactionFragmentDoc = gql`
+    fragment reaction on ReactionResponse {
+  id
+  createdAt
+  updatedAt
+  canceledAt
+  emoji {
+    ...emoji
+  }
+  userId
+  postId
+  commentId
+}
+    ${EmojiFragmentDoc}`;
 export const LastReportFragmentDoc = gql`
     fragment lastReport on LastReportResponse {
   id
@@ -1950,73 +1948,10 @@ export const UserReviewPreviewFragmentDoc = gql`
 }
     ${PostPreviewWithAuthorFragmentDoc}
 ${AuthorFragmentDoc}`;
-export const EmojiFragmentDoc = gql`
-    fragment emoji on EmojiResponse {
-  id
-  name
-  url
-  position
-  groupId
-}
-    `;
-export const ReactionFragmentDoc = gql`
-    fragment reaction on ReactionResponse {
-  id
-  createdAt
-  updatedAt
-  canceledAt
-  emoji {
-    ...emoji
-  }
-  userId
-  postId
-  commentId
-}
-    ${EmojiFragmentDoc}`;
-export const PostWithReactionsFragmentDoc = gql`
-    fragment postWithReactions on PostWithReactionsResponse {
-  id
-  createdAt
-  updatedAt
-  archivedAt
-  pending
-  type
-  title
-  slug
-  thumbnail
-  reportCount
-  reportCommentCount
-  images {
-    ...image
-  }
-  groupId
-  group {
-    ...groupProfile
-  }
-  categoryId
-  category {
-    ...category
-  }
-  user {
-    ...author
-  }
-  tags {
-    ...tag
-  }
-  reactions {
-    ...reaction
-  }
-}
-    ${ImageFragmentDoc}
-${GroupProfileFragmentDoc}
-${CategoryFragmentDoc}
-${AuthorFragmentDoc}
-${TagFragmentDoc}
-${ReactionFragmentDoc}`;
 export const UserReviewFragmentDoc = gql`
     fragment userReview on UserReviewResponse {
   post {
-    ...postWithReactions
+    ...post
   }
   id
   createdAt
@@ -2031,7 +1966,7 @@ export const UserReviewFragmentDoc = gql`
   rating
   status
 }
-    ${PostWithReactionsFragmentDoc}
+    ${PostFragmentDoc}
 ${AuthorFragmentDoc}`;
 export const SocialAccountFragmentDoc = gql`
     fragment socialAccount on SocialAccountResponse {

--- a/generated/graphql.ts
+++ b/generated/graphql.ts
@@ -631,6 +631,7 @@ export type Query = {
   findOfferCount: Scalars['Float']['output'];
   findOfferPreviews: PaginatedOfferPreviewsResponse;
   findPostPreview: PostPreviewWithUserResponse;
+  findReactions: Array<ReactionResponse>;
   findReport: ReportResponse;
   findReportComment: ReportCommentResponse;
   findReportPreviews: PaginatedReportPreviewsResponse;
@@ -722,6 +723,12 @@ export type QueryFindOfferPreviewsArgs = {
 
 export type QueryFindPostPreviewArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+export type QueryFindReactionsArgs = {
+  commentId?: InputMaybe<Scalars['ID']['input']>;
+  postId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 
@@ -921,6 +928,11 @@ export type Subscription = {
   commentCreated: CommentWithAuthorResponse;
   reactionCanceled: CanceledReactionResponse;
   reactionCreated: ReactionResponse;
+};
+
+
+export type SubscriptionCommentCreatedArgs = {
+  postId: Scalars['ID']['input'];
 };
 
 export type TagResponse = {
@@ -1160,7 +1172,9 @@ export type FindCommentsQueryVariables = Exact<{
 
 export type FindCommentsQuery = { __typename?: 'Query', findComments: { __typename?: 'PaginatedCommentsResponse', edges: Array<{ __typename?: 'CommentWithAuthorResponseEdge', cursor: string, node: { __typename?: 'CommentWithAuthorResponse', id: string, createdAt: any, updatedAt: any, parentId?: string | null, postId: string, content: string, user: { __typename?: 'AuthorResponse', id: string, createdAt: any, username: string, about?: string | null, avatarURL?: string | null, bot: boolean, socialAccounts: Array<{ __typename?: 'SocialAccountWithoutAuthResponse', id: string, createdAt: any, provider: string, socialId: string, userId: string }>, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, groupId: string }> } } }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } } };
 
-export type CommentCreatedSubscriptionVariables = Exact<{ [key: string]: never; }>;
+export type CommentCreatedSubscriptionVariables = Exact<{
+  postId: Scalars['ID']['input'];
+}>;
 
 
 export type CommentCreatedSubscription = { __typename?: 'Subscription', commentCreated: { __typename?: 'CommentWithAuthorResponse', id: string, createdAt: any, updatedAt: any, parentId?: string | null, postId: string, content: string, user: { __typename?: 'AuthorResponse', id: string, createdAt: any, username: string, about?: string | null, avatarURL?: string | null, bot: boolean, socialAccounts: Array<{ __typename?: 'SocialAccountWithoutAuthResponse', id: string, createdAt: any, provider: string, socialId: string, userId: string }>, roles: Array<{ __typename?: 'RoleResponse', id: string, name: string, position?: number | null, hexColor: string, groupId: string }> } } };
@@ -1296,6 +1310,14 @@ export type CancelReactionMutationVariables = Exact<{
 
 
 export type CancelReactionMutation = { __typename?: 'Mutation', cancelReaction: string };
+
+export type FindReactionsQueryVariables = Exact<{
+  postId?: InputMaybe<Scalars['ID']['input']>;
+  commentId?: InputMaybe<Scalars['ID']['input']>;
+}>;
+
+
+export type FindReactionsQuery = { __typename?: 'Query', findReactions: Array<{ __typename?: 'ReactionResponse', id: string, createdAt: any, updatedAt: any, canceledAt?: any | null, userId: string, postId?: string | null, commentId?: string | null, emoji: { __typename?: 'EmojiResponse', id: string, name: string, url?: string | null, position: number, groupId?: string | null } }> };
 
 export type ReactionCreatedSubscriptionVariables = Exact<{ [key: string]: never; }>;
 
@@ -2313,8 +2335,8 @@ export type FindCommentsLazyQueryHookResult = ReturnType<typeof useFindCommentsL
 export type FindCommentsSuspenseQueryHookResult = ReturnType<typeof useFindCommentsSuspenseQuery>;
 export type FindCommentsQueryResult = Apollo.QueryResult<FindCommentsQuery, FindCommentsQueryVariables>;
 export const CommentCreatedDocument = gql`
-    subscription CommentCreated {
-  commentCreated {
+    subscription CommentCreated($postId: ID!) {
+  commentCreated(postId: $postId) {
     ...commentWithAuthor
   }
 }
@@ -2332,10 +2354,11 @@ export const CommentCreatedDocument = gql`
  * @example
  * const { data, loading, error } = useCommentCreatedSubscription({
  *   variables: {
+ *      postId: // value for 'postId'
  *   },
  * });
  */
-export function useCommentCreatedSubscription(baseOptions?: Apollo.SubscriptionHookOptions<CommentCreatedSubscription, CommentCreatedSubscriptionVariables>) {
+export function useCommentCreatedSubscription(baseOptions: Apollo.SubscriptionHookOptions<CommentCreatedSubscription, CommentCreatedSubscriptionVariables> & ({ variables: CommentCreatedSubscriptionVariables; skip?: boolean; } | { skip: boolean; }) ) {
         const options = {...defaultOptions, ...baseOptions}
         return Apollo.useSubscription<CommentCreatedSubscription, CommentCreatedSubscriptionVariables>(CommentCreatedDocument, options);
       }
@@ -2909,6 +2932,47 @@ export function useCancelReactionMutation(baseOptions?: Apollo.MutationHookOptio
 export type CancelReactionMutationHookResult = ReturnType<typeof useCancelReactionMutation>;
 export type CancelReactionMutationResult = Apollo.MutationResult<CancelReactionMutation>;
 export type CancelReactionMutationOptions = Apollo.BaseMutationOptions<CancelReactionMutation, CancelReactionMutationVariables>;
+export const FindReactionsDocument = gql`
+    query findReactions($postId: ID, $commentId: ID) {
+  findReactions(postId: $postId, commentId: $commentId) {
+    ...reaction
+  }
+}
+    ${ReactionFragmentDoc}`;
+
+/**
+ * __useFindReactionsQuery__
+ *
+ * To run a query within a React component, call `useFindReactionsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useFindReactionsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useFindReactionsQuery({
+ *   variables: {
+ *      postId: // value for 'postId'
+ *      commentId: // value for 'commentId'
+ *   },
+ * });
+ */
+export function useFindReactionsQuery(baseOptions?: Apollo.QueryHookOptions<FindReactionsQuery, FindReactionsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<FindReactionsQuery, FindReactionsQueryVariables>(FindReactionsDocument, options);
+      }
+export function useFindReactionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<FindReactionsQuery, FindReactionsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<FindReactionsQuery, FindReactionsQueryVariables>(FindReactionsDocument, options);
+        }
+export function useFindReactionsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindReactionsQuery, FindReactionsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<FindReactionsQuery, FindReactionsQueryVariables>(FindReactionsDocument, options);
+        }
+export type FindReactionsQueryHookResult = ReturnType<typeof useFindReactionsQuery>;
+export type FindReactionsLazyQueryHookResult = ReturnType<typeof useFindReactionsLazyQuery>;
+export type FindReactionsSuspenseQueryHookResult = ReturnType<typeof useFindReactionsSuspenseQuery>;
+export type FindReactionsQueryResult = Apollo.QueryResult<FindReactionsQuery, FindReactionsQueryVariables>;
 export const ReactionCreatedDocument = gql`
     subscription ReactionCreated {
   reactionCreated {

--- a/generated/graphql.ts
+++ b/generated/graphql.ts
@@ -40,12 +40,14 @@ export type BumpOfferInput = {
 export type CancelReactionInput = {
   commentId?: InputMaybe<Scalars['ID']['input']>;
   emojiId: Scalars['ID']['input'];
-  postId?: InputMaybe<Scalars['ID']['input']>;
+  postId: Scalars['ID']['input'];
 };
 
 export type CanceledReactionResponse = {
   __typename?: 'CanceledReactionResponse';
+  commentId?: Maybe<Scalars['ID']['output']>;
   id: Scalars['ID']['output'];
+  postId: Scalars['ID']['output'];
 };
 
 export type CategoryResponse = {
@@ -138,7 +140,7 @@ export type CreateReactionInput = {
   commentId?: InputMaybe<Scalars['ID']['input']>;
   emojiId: Scalars['ID']['input'];
   id: Scalars['ID']['input'];
-  postId?: InputMaybe<Scalars['ID']['input']>;
+  postId: Scalars['ID']['input'];
 };
 
 export type CreateReportInput = {
@@ -823,7 +825,7 @@ export type ReactionResponse = {
   createdAt: Scalars['DateTime']['output'];
   emoji: EmojiResponse;
   id: Scalars['ID']['output'];
-  postId?: Maybe<Scalars['ID']['output']>;
+  postId: Scalars['ID']['output'];
   updatedAt: Scalars['DateTime']['output'];
   userId: Scalars['ID']['output'];
 };
@@ -937,14 +939,14 @@ export type SubscriptionCommentCreatedArgs = {
 
 
 export type SubscriptionReactionCanceledArgs = {
-  commentId?: InputMaybe<Scalars['ID']['input']>;
-  postId?: InputMaybe<Scalars['ID']['input']>;
+  postId: Scalars['ID']['input'];
+  type: Scalars['String']['input'];
 };
 
 
 export type SubscriptionReactionCreatedArgs = {
-  commentId?: InputMaybe<Scalars['ID']['input']>;
-  postId?: InputMaybe<Scalars['ID']['input']>;
+  postId: Scalars['ID']['input'];
+  type: Scalars['String']['input'];
 };
 
 export type TagResponse = {
@@ -1307,7 +1309,7 @@ export type FindPostPreviewQueryVariables = Exact<{
 
 export type FindPostPreviewQuery = { __typename?: 'Query', findPostPreview: { __typename?: 'PostPreviewWithUserResponse', id: string, createdAt: any, updatedAt: any, archivedAt?: any | null, pending?: string | null, type: string, title: string, slug?: string | null, thumbnail?: string | null, groupId: string, categoryId?: string | null, reportCount: number, reportCommentCount: number, user: { __typename?: 'UserResponse', id: string, createdAt: any, username: string, about?: string | null, avatarURL?: string | null, bot: boolean }, tags: Array<{ __typename?: 'TagResponse', id: string, type: string, name: string, description?: string | null, position: number }> } };
 
-export type ReactionFragment = { __typename?: 'ReactionResponse', id: string, createdAt: any, updatedAt: any, canceledAt?: any | null, userId: string, postId?: string | null, commentId?: string | null, emoji: { __typename?: 'EmojiResponse', id: string, name: string, url?: string | null, position: number, groupId?: string | null } };
+export type ReactionFragment = { __typename?: 'ReactionResponse', id: string, createdAt: any, updatedAt: any, canceledAt?: any | null, userId: string, postId: string, commentId?: string | null, emoji: { __typename?: 'EmojiResponse', id: string, name: string, url?: string | null, position: number, groupId?: string | null } };
 
 export type CreateReactionMutationVariables = Exact<{
   input: CreateReactionInput;
@@ -1329,23 +1331,23 @@ export type FindReactionsQueryVariables = Exact<{
 }>;
 
 
-export type FindReactionsQuery = { __typename?: 'Query', findReactions: Array<{ __typename?: 'ReactionResponse', id: string, createdAt: any, updatedAt: any, canceledAt?: any | null, userId: string, postId?: string | null, commentId?: string | null, emoji: { __typename?: 'EmojiResponse', id: string, name: string, url?: string | null, position: number, groupId?: string | null } }> };
+export type FindReactionsQuery = { __typename?: 'Query', findReactions: Array<{ __typename?: 'ReactionResponse', id: string, createdAt: any, updatedAt: any, canceledAt?: any | null, userId: string, postId: string, commentId?: string | null, emoji: { __typename?: 'EmojiResponse', id: string, name: string, url?: string | null, position: number, groupId?: string | null } }> };
 
 export type ReactionCreatedSubscriptionVariables = Exact<{
-  postId?: InputMaybe<Scalars['ID']['input']>;
-  commentId?: InputMaybe<Scalars['ID']['input']>;
+  type: Scalars['String']['input'];
+  postId: Scalars['ID']['input'];
 }>;
 
 
-export type ReactionCreatedSubscription = { __typename?: 'Subscription', reactionCreated: { __typename?: 'ReactionResponse', id: string, createdAt: any, updatedAt: any, canceledAt?: any | null, userId: string, postId?: string | null, commentId?: string | null, emoji: { __typename?: 'EmojiResponse', id: string, name: string, url?: string | null, position: number, groupId?: string | null } } };
+export type ReactionCreatedSubscription = { __typename?: 'Subscription', reactionCreated: { __typename?: 'ReactionResponse', id: string, createdAt: any, updatedAt: any, canceledAt?: any | null, userId: string, postId: string, commentId?: string | null, emoji: { __typename?: 'EmojiResponse', id: string, name: string, url?: string | null, position: number, groupId?: string | null } } };
 
 export type ReactionCanceledSubscriptionVariables = Exact<{
-  postId?: InputMaybe<Scalars['ID']['input']>;
-  commentId?: InputMaybe<Scalars['ID']['input']>;
+  type: Scalars['String']['input'];
+  postId: Scalars['ID']['input'];
 }>;
 
 
-export type ReactionCanceledSubscription = { __typename?: 'Subscription', reactionCanceled: { __typename?: 'CanceledReactionResponse', id: string } };
+export type ReactionCanceledSubscription = { __typename?: 'Subscription', reactionCanceled: { __typename?: 'CanceledReactionResponse', id: string, postId: string, commentId?: string | null } };
 
 export type LastReportFragment = { __typename?: 'LastReportResponse', id: string, createdAt: any };
 
@@ -2992,8 +2994,8 @@ export type FindReactionsLazyQueryHookResult = ReturnType<typeof useFindReaction
 export type FindReactionsSuspenseQueryHookResult = ReturnType<typeof useFindReactionsSuspenseQuery>;
 export type FindReactionsQueryResult = Apollo.QueryResult<FindReactionsQuery, FindReactionsQueryVariables>;
 export const ReactionCreatedDocument = gql`
-    subscription ReactionCreated($postId: ID, $commentId: ID) {
-  reactionCreated(postId: $postId, commentId: $commentId) {
+    subscription ReactionCreated($type: String!, $postId: ID!) {
+  reactionCreated(type: $type, postId: $postId) {
     ...reaction
   }
 }
@@ -3011,21 +3013,23 @@ export const ReactionCreatedDocument = gql`
  * @example
  * const { data, loading, error } = useReactionCreatedSubscription({
  *   variables: {
+ *      type: // value for 'type'
  *      postId: // value for 'postId'
- *      commentId: // value for 'commentId'
  *   },
  * });
  */
-export function useReactionCreatedSubscription(baseOptions?: Apollo.SubscriptionHookOptions<ReactionCreatedSubscription, ReactionCreatedSubscriptionVariables>) {
+export function useReactionCreatedSubscription(baseOptions: Apollo.SubscriptionHookOptions<ReactionCreatedSubscription, ReactionCreatedSubscriptionVariables> & ({ variables: ReactionCreatedSubscriptionVariables; skip?: boolean; } | { skip: boolean; }) ) {
         const options = {...defaultOptions, ...baseOptions}
         return Apollo.useSubscription<ReactionCreatedSubscription, ReactionCreatedSubscriptionVariables>(ReactionCreatedDocument, options);
       }
 export type ReactionCreatedSubscriptionHookResult = ReturnType<typeof useReactionCreatedSubscription>;
 export type ReactionCreatedSubscriptionResult = Apollo.SubscriptionResult<ReactionCreatedSubscription>;
 export const ReactionCanceledDocument = gql`
-    subscription ReactionCanceled($postId: ID, $commentId: ID) {
-  reactionCanceled(postId: $postId, commentId: $commentId) {
+    subscription ReactionCanceled($type: String!, $postId: ID!) {
+  reactionCanceled(type: $type, postId: $postId) {
     id
+    postId
+    commentId
   }
 }
     `;
@@ -3042,12 +3046,12 @@ export const ReactionCanceledDocument = gql`
  * @example
  * const { data, loading, error } = useReactionCanceledSubscription({
  *   variables: {
+ *      type: // value for 'type'
  *      postId: // value for 'postId'
- *      commentId: // value for 'commentId'
  *   },
  * });
  */
-export function useReactionCanceledSubscription(baseOptions?: Apollo.SubscriptionHookOptions<ReactionCanceledSubscription, ReactionCanceledSubscriptionVariables>) {
+export function useReactionCanceledSubscription(baseOptions: Apollo.SubscriptionHookOptions<ReactionCanceledSubscription, ReactionCanceledSubscriptionVariables> & ({ variables: ReactionCanceledSubscriptionVariables; skip?: boolean; } | { skip: boolean; }) ) {
         const options = {...defaultOptions, ...baseOptions}
         return Apollo.useSubscription<ReactionCanceledSubscription, ReactionCanceledSubscriptionVariables>(ReactionCanceledDocument, options);
       }

--- a/generated/graphql.ts
+++ b/generated/graphql.ts
@@ -935,6 +935,18 @@ export type SubscriptionCommentCreatedArgs = {
   postId: Scalars['ID']['input'];
 };
 
+
+export type SubscriptionReactionCanceledArgs = {
+  commentId?: InputMaybe<Scalars['ID']['input']>;
+  postId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+
+export type SubscriptionReactionCreatedArgs = {
+  commentId?: InputMaybe<Scalars['ID']['input']>;
+  postId?: InputMaybe<Scalars['ID']['input']>;
+};
+
 export type TagResponse = {
   __typename?: 'TagResponse';
   description?: Maybe<Scalars['String']['output']>;
@@ -1319,12 +1331,18 @@ export type FindReactionsQueryVariables = Exact<{
 
 export type FindReactionsQuery = { __typename?: 'Query', findReactions: Array<{ __typename?: 'ReactionResponse', id: string, createdAt: any, updatedAt: any, canceledAt?: any | null, userId: string, postId?: string | null, commentId?: string | null, emoji: { __typename?: 'EmojiResponse', id: string, name: string, url?: string | null, position: number, groupId?: string | null } }> };
 
-export type ReactionCreatedSubscriptionVariables = Exact<{ [key: string]: never; }>;
+export type ReactionCreatedSubscriptionVariables = Exact<{
+  postId?: InputMaybe<Scalars['ID']['input']>;
+  commentId?: InputMaybe<Scalars['ID']['input']>;
+}>;
 
 
 export type ReactionCreatedSubscription = { __typename?: 'Subscription', reactionCreated: { __typename?: 'ReactionResponse', id: string, createdAt: any, updatedAt: any, canceledAt?: any | null, userId: string, postId?: string | null, commentId?: string | null, emoji: { __typename?: 'EmojiResponse', id: string, name: string, url?: string | null, position: number, groupId?: string | null } } };
 
-export type ReactionCanceledSubscriptionVariables = Exact<{ [key: string]: never; }>;
+export type ReactionCanceledSubscriptionVariables = Exact<{
+  postId?: InputMaybe<Scalars['ID']['input']>;
+  commentId?: InputMaybe<Scalars['ID']['input']>;
+}>;
 
 
 export type ReactionCanceledSubscription = { __typename?: 'Subscription', reactionCanceled: { __typename?: 'CanceledReactionResponse', id: string } };
@@ -2974,8 +2992,8 @@ export type FindReactionsLazyQueryHookResult = ReturnType<typeof useFindReaction
 export type FindReactionsSuspenseQueryHookResult = ReturnType<typeof useFindReactionsSuspenseQuery>;
 export type FindReactionsQueryResult = Apollo.QueryResult<FindReactionsQuery, FindReactionsQueryVariables>;
 export const ReactionCreatedDocument = gql`
-    subscription ReactionCreated {
-  reactionCreated {
+    subscription ReactionCreated($postId: ID, $commentId: ID) {
+  reactionCreated(postId: $postId, commentId: $commentId) {
     ...reaction
   }
 }
@@ -2993,6 +3011,8 @@ export const ReactionCreatedDocument = gql`
  * @example
  * const { data, loading, error } = useReactionCreatedSubscription({
  *   variables: {
+ *      postId: // value for 'postId'
+ *      commentId: // value for 'commentId'
  *   },
  * });
  */
@@ -3003,8 +3023,8 @@ export function useReactionCreatedSubscription(baseOptions?: Apollo.Subscription
 export type ReactionCreatedSubscriptionHookResult = ReturnType<typeof useReactionCreatedSubscription>;
 export type ReactionCreatedSubscriptionResult = Apollo.SubscriptionResult<ReactionCreatedSubscription>;
 export const ReactionCanceledDocument = gql`
-    subscription ReactionCanceled {
-  reactionCanceled {
+    subscription ReactionCanceled($postId: ID, $commentId: ID) {
+  reactionCanceled(postId: $postId, commentId: $commentId) {
     id
   }
 }
@@ -3022,6 +3042,8 @@ export const ReactionCanceledDocument = gql`
  * @example
  * const { data, loading, error } = useReactionCanceledSubscription({
  *   variables: {
+ *      postId: // value for 'postId'
+ *      commentId: // value for 'commentId'
  *   },
  * });
  */

--- a/hooks/use-infinite-comments.ts
+++ b/hooks/use-infinite-comments.ts
@@ -27,7 +27,8 @@ export const useInfiniteComments = ({
       take,
       skip: 0,
     },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-and-network',
+    nextFetchPolicy: 'cache-and-network',
   });
 
   useInfiniteScroll(

--- a/lib/graphql/comment.graphql
+++ b/lib/graphql/comment.graphql
@@ -80,8 +80,8 @@ query findComments(
   }
 }
 
-subscription CommentCreated {
-  commentCreated {
+subscription CommentCreated($postId: ID!) {
+  commentCreated(postId: $postId) {
     ...commentWithAuthor
   }
 }

--- a/lib/graphql/post.graphql
+++ b/lib/graphql/post.graphql
@@ -29,40 +29,6 @@ fragment post on PostResponse {
   }
 }
 
-fragment postWithReactions on PostWithReactionsResponse {
-  id
-  createdAt
-  updatedAt
-  archivedAt
-  pending
-  type
-  title
-  slug
-  thumbnail
-  reportCount
-  reportCommentCount
-  images {
-    ...image
-  }
-  groupId
-  group {
-    ...groupProfile
-  }
-  categoryId
-  category {
-    ...category
-  }
-  user {
-    ...author
-  }
-  tags {
-    ...tag
-  }
-  reactions {
-    ...reaction
-  }
-}
-
 fragment postPreviewWithoutUser on PostPreviewWithoutUserResponse {
   id
   createdAt

--- a/lib/graphql/reaction.graphql
+++ b/lib/graphql/reaction.graphql
@@ -24,3 +24,9 @@ subscription ReactionCreated {
     ...reaction
   }
 }
+
+subscription ReactionCanceled {
+  reactionCanceled {
+    id
+  }
+}

--- a/lib/graphql/reaction.graphql
+++ b/lib/graphql/reaction.graphql
@@ -32,25 +32,27 @@ query findReactions(
 }
 
 subscription ReactionCreated(
-  $postId: ID
-  $commentId: ID
+  $type: String!
+  $postId: ID!
 ) {
   reactionCreated(
+    type: $type
     postId: $postId
-    commentId: $commentId
   ) {
     ...reaction
   }
 }
 
 subscription ReactionCanceled(
-  $postId: ID
-  $commentId: ID
+  $type: String!
+  $postId: ID!
 ) {
   reactionCanceled(
+    type: $type
     postId: $postId
-    commentId: $commentId
   ) {
     id
+    postId
+    commentId
   }
 }

--- a/lib/graphql/reaction.graphql
+++ b/lib/graphql/reaction.graphql
@@ -31,14 +31,26 @@ query findReactions(
   }
 }
 
-subscription ReactionCreated {
-  reactionCreated {
+subscription ReactionCreated(
+  $postId: ID
+  $commentId: ID
+) {
+  reactionCreated(
+    postId: $postId
+    commentId: $commentId
+  ) {
     ...reaction
   }
 }
 
-subscription ReactionCanceled {
-  reactionCanceled {
+subscription ReactionCanceled(
+  $postId: ID
+  $commentId: ID
+) {
+  reactionCanceled(
+    postId: $postId
+    commentId: $commentId
+  ) {
     id
   }
 }

--- a/lib/graphql/reaction.graphql
+++ b/lib/graphql/reaction.graphql
@@ -19,6 +19,18 @@ mutation CancelReaction($input: CancelReactionInput!) {
   cancelReaction(input: $input)
 }
 
+query findReactions(
+  $postId: ID
+  $commentId: ID
+) {
+  findReactions(
+    postId: $postId
+    commentId: $commentId
+  ) {
+    ...reaction
+  }
+}
+
 subscription ReactionCreated {
   reactionCreated {
     ...reaction

--- a/lib/graphql/reaction.graphql
+++ b/lib/graphql/reaction.graphql
@@ -18,3 +18,9 @@ mutation CreateReaction($input: CreateReactionInput!) {
 mutation CancelReaction($input: CancelReactionInput!) {
   cancelReaction(input: $input)
 }
+
+subscription ReactionCreated {
+  reactionCreated {
+    ...reaction
+  }
+}

--- a/lib/graphql/user-review.graphql
+++ b/lib/graphql/user-review.graphql
@@ -18,7 +18,7 @@ fragment userReviewPreview on UserReviewPreviewResponse {
 
 fragment userReview on UserReviewResponse {
   post {
-    ...postWithReactions
+    ...post
   }
   id
   createdAt

--- a/lib/scroll/scroll-to-bottom.ts
+++ b/lib/scroll/scroll-to-bottom.ts
@@ -1,0 +1,6 @@
+export const scrollToBottom = () => {
+  window.scrollTo({
+    top: document.body.scrollHeight,
+    behavior: 'smooth',
+  });
+};


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
1. post response에서 reactions 분리
2. 댓글에서의 reaction 추가, 취소 실시간 업데이트
3. comment feed의 내부 scroll 제거

## 어떻게 해결했나요?
1. post에 reactions을 포함하지 않고, find reactions을 통해 가져오기
2. CommentOupt에서 postId를 variable로 reactionCreated, reactionCanceled subcription
3. Comment Feed에서 overflow-y-auto를 지우고, window scroll로 처리
