### PR TITLE
fix: handle double input problem of korean keys, and change threshold in IntersectionObserver

### DIFF
--- a/app/write/review/offer/[offerId]/page.tsx
+++ b/app/write/review/offer/[offerId]/page.tsx
@@ -66,16 +66,14 @@ export default function Page({
         handleKeyDown={handleKeyDown}
         handleChange={handleChange}
       />
-      <div className="pt-4 overflow-y-scroll">
-        <div style={{ maxHeight: '75vh' }} className="grid gap-2">
-          <UserCheckboxResults
-            where={where}
-            keyword={keyword}
-            userIdToExclude={jwtPayload?.id}
-            control={control}
-            handleOfferSelection={handleOfferSelection}
-          />
-        </div>
+      <div className="pt-4 overflow-y-scroll max-h-[75vh] grid gap-2 grid-cols-1">
+        <UserCheckboxResults
+          where={where}
+          keyword={keyword}
+          userIdToExclude={jwtPayload?.id}
+          control={control}
+          handleOfferSelection={handleOfferSelection}
+        />
       </div>
       <div className="pt-4" />
       <NextDialog

--- a/app/write/review/user/[userId]/page.tsx
+++ b/app/write/review/user/[userId]/page.tsx
@@ -66,17 +66,15 @@ export default function Page({
         handleKeyDown={handleKeyDown}
         handleChange={handleChange}
       />
-      <div className="pt-4 overflow-y-scroll">
-        <div style={{ maxHeight: '75vh' }} className="grid gap-2">
-          <OfferCheckboxResults
-            where={where}
-            type="text"
-            keyword={keyword}
-            distinct={false}
-            control={control}
-            handleOfferSelection={handleOfferSelection}
-          />
-        </div>
+      <div className="pt-4 overflow-y-scroll max-h-[75vh] grid gap-2 grid-cols-1">
+        <OfferCheckboxResults
+          where={where}
+          type="text"
+          keyword={keyword}
+          distinct={false}
+          control={control}
+          handleOfferSelection={handleOfferSelection}
+        />
       </div>
       <div className="pt-4" />
       <NextDialog

--- a/components/comments/comment-card.tsx
+++ b/components/comments/comment-card.tsx
@@ -90,6 +90,7 @@ export default function CommentCard({
   };
 
   const handleKeyDown: KeyboardEventHandler = (event) => {
+    if (event.nativeEvent.isComposing) return;
     if (event.code === 'Enter') {
       event.preventDefault();
       handleSubmitValid(getValues(), event);

--- a/components/info/info-feed-layout.tsx
+++ b/components/info/info-feed-layout.tsx
@@ -5,7 +5,7 @@ interface Props {
 }
 
 function InfoFeedLayout({ children }: Props) {
-  return <div className="grid gap-1 grid-cols-1 pt-4">{children}</div>;
+  return <div className="grid gap-2 grid-cols-1 pt-4">{children}</div>;
 }
 
 export default InfoFeedLayout;

--- a/components/offers/offer-checkbox-results.tsx
+++ b/components/offers/offer-checkbox-results.tsx
@@ -79,7 +79,7 @@ function OfferCheckboxResults({
           </div>
         </div>
       ))}
-      <div ref={ref} />
+      <div ref={ref} className="h-1" />
     </>
   );
 }

--- a/components/search/product-search-results.tsx
+++ b/components/search/product-search-results.tsx
@@ -19,7 +19,7 @@ export default function ProductSearchResults({
         <div className="text-gray-300 text-sm md:text-base font-bold m-2">
           팝니다
         </div>
-        <div className="grid gap-1 grid-cols-1 max-h-[470px] md:max-h-[800px] overflow-y-scroll">
+        <div className="grid gap-2 grid-cols-1 max-h-[470px] md:max-h-[800px] overflow-y-scroll">
           {keyword ? (
             <OfferFeed
               where={{
@@ -43,7 +43,7 @@ export default function ProductSearchResults({
         <div className="text-gray-300 text-sm md:text-base font-bold m-2">
           삽니다
         </div>
-        <div className="grid gap-1 grid-cols-1 max-h-[470px] md:max-h-[800px] overflow-y-scroll">
+        <div className="grid gap-2 grid-cols-1 max-h-[470px] md:max-h-[800px] overflow-y-scroll">
           {keyword ? (
             <OfferFeed
               where={{

--- a/components/users/user-checkbox-results.tsx
+++ b/components/users/user-checkbox-results.tsx
@@ -73,8 +73,7 @@ function UserCheckboxResults({
           </div>
         </div>
       ))}
-      {/* gap-2 */}
-      <div ref={ref} className="h-2" />
+      <div ref={ref} className="h-1" />
     </>
   );
 }

--- a/components/users/user-checkbox-results.tsx
+++ b/components/users/user-checkbox-results.tsx
@@ -73,7 +73,8 @@ function UserCheckboxResults({
           </div>
         </div>
       ))}
-      <div ref={ref} />
+      {/* gap-2 */}
+      <div ref={ref} className="h-2" />
     </>
   );
 }

--- a/hooks/use-infinite-scroll.ts
+++ b/hooks/use-infinite-scroll.ts
@@ -19,7 +19,7 @@ export const useInfiniteScroll = (
       },
       {
         rootMargin: '300px',
-        threshold: 1,
+        threshold: 0.9,
       },
     );
     observer.observe(ref.current);


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
1. check box results에서 infinite scroll이 fetch more을 실행하지 않는 문제
2. 한글 키입력시 두 번 event가 발생하는 문제

## 어떻게 해결했나요?
1. ref div에 h-1 설정, threshold: 1->0.9
2. 한글 조합 event는 무시 - event.nativeEvent.isComposing return;
