### PR TITLE
fix: change default status in user home offer feed

### DIFF
--- a/app/user/[username]/(home)/report/submitted/page.tsx
+++ b/app/user/[username]/(home)/report/submitted/page.tsx
@@ -25,7 +25,7 @@ function Page({
   if (!user) return <div />;
 
   const where: FindReportPreviewsWhereArgs = {
-    authorId: user.id,
+    userId: user.id,
   };
   const orderBy: FindReportPreviewsOrderByArgs = {
     createdAt: 'desc',

--- a/components/offers/offer-status-navbar.tsx
+++ b/components/offers/offer-status-navbar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { usePathname, useSearchParams } from 'next/navigation';
-import { OFFER_IS_ARCHIVED, OFFER_OPEN } from '@/lib/offer/offer.constants';
+import { OFFER_IS_ARCHIVED } from '@/lib/offer/offer.constants';
 import createQueryString from '@/lib/query-string/create-query-string';
 import { Option } from '@/interfaces/selector.interfaces';
 import TextNavbar from '../base/text-navbar';
@@ -12,7 +12,7 @@ export default function OfferStatusNavbar({ options }: { options: Option[] }) {
   const selectedValue =
     searchParams.get('isArchived') === true.toString()
       ? OFFER_IS_ARCHIVED
-      : searchParams.get('status') || OFFER_OPEN;
+      : searchParams.get('status') || 'all';
 
   const parseNewURL = (newValue?: string) => {
     let queryString = createQueryString({

--- a/interfaces/report.interfaces.ts
+++ b/interfaces/report.interfaces.ts
@@ -5,7 +5,7 @@ export interface FindReportPreviewsWhereArgs {
 
   refId?: string;
 
-  authorId?: string;
+  userId?: string;
 
   reportedUserId?: string;
 

--- a/lib/offer/offer.constants.ts
+++ b/lib/offer/offer.constants.ts
@@ -13,6 +13,7 @@ export const OFFER_STATUS_OPTIONS = [
 ];
 
 export const PRIVATE_USER_OFFER_STATUS_OPTIONS = [
+  { value: 'all', label: '모든 상태' },
   { value: 'open', label: '거래 가능' },
   { value: 'closed', label: '거래 완료' },
   { value: 'isArchived', label: '보관' },


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
1. 유저가 다른 유저의 거래글을 볼 때, 모든 상태가 아닌 open 상태 거래글만 불러오는 문제
2. find report previews의 where args 변수명 오류

## 어떻게 해결했나요?
1. default status 를 open -> all로 변경, 유저 본인의 거래글 피드 필터 항목에도 모든 상태 추가
2. authorId -> userId
